### PR TITLE
fix(svg_to_pptx): tolerate HTML named entities in AI-generated SVG

### DIFF
--- a/skills/ppt-master/scripts/svg_to_pptx/drawingml_converter.py
+++ b/skills/ppt-master/scripts/svg_to_pptx/drawingml_converter.py
@@ -3,8 +3,31 @@
 from __future__ import annotations
 
 import re
+from html.entities import html5 as _HTML5_ENTITIES
 from pathlib import Path
 from xml.etree import ElementTree as ET
+
+# AI-generated SVGs frequently contain HTML named entities such as &nbsp;
+# &mdash; &copy;.  SVG is strict XML, so ElementTree only recognises the five
+# XML reserved entities (lt/gt/amp/quot/apos) and raises ParseError on the
+# rest.  This pre-parse pass replaces unknown HTML entities with their Unicode
+# code-point equivalents (e.g. &nbsp; -> U+00A0); the five XML reserved
+# entities and numeric character references (&#160; / &#xa0;) are kept
+# verbatim, and any unrecognised entity is left untouched so the parser can
+# still surface a clear error.
+_XML_RESERVED_ENTITIES = {"lt", "gt", "amp", "quot", "apos"}
+_ENTITY_RE = re.compile(r"&([#a-zA-Z][a-zA-Z0-9]*);")
+
+
+def _sanitize_svg_text(text: str) -> str:
+    def _replace(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name in _XML_RESERVED_ENTITIES or name.startswith("#"):
+            return match.group(0)
+        char = _HTML5_ENTITIES.get(name + ";") or _HTML5_ENTITIES.get(name)
+        return char if char else match.group(0)
+
+    return _ENTITY_RE.sub(_replace, text)
 
 from .drawingml_context import ConvertContext, ShapeResult
 from .drawingml_utils import (
@@ -212,7 +235,9 @@ def convert_svg_to_slide_shapes(
         - media_files: Dict of {filename: bytes} for media to write.
         - rel_entries: List of relationship entries to add.
     """
-    tree = ET.parse(str(svg_path))
+    raw_text = Path(svg_path).read_text(encoding="utf-8")
+    sanitized = _sanitize_svg_text(raw_text)
+    tree = ET.ElementTree(ET.fromstring(sanitized))
     root = tree.getroot()
 
     defs = collect_defs(root)


### PR DESCRIPTION
## Problem

`xml.etree.ElementTree` only recognises the five XML reserved entities (`lt`, `gt`, `amp`, `quot`, `apos`). When an SVG contains an HTML named entity such as `&nbsp;`, `&mdash;`, or `&copy;`, parsing aborts with:

```
xml.etree.ElementTree.ParseError: undefined entity: line N, column M
```

This is a recurring issue with AI-generated decks — Claude / GPT / Gemini frequently emit `&nbsp;` inside `<text>`. A single offending slide currently kills the export of an entire deck. In real usage I just hit this on slide 4 of a 16-slide consulting-style PPT, and even though 15/16 slides converted fine, the whole `.pptx` was discarded.

## Fix

Pre-parse pass that replaces every **unknown** HTML named entity with its Unicode code point (`&nbsp;` → U+00A0, `&mdash;` → U+2014, etc.) by looking it up in `html.entities.html5`. The five XML reserved entities and numeric character references (`&#160;` / `&#xa0;`) pass through unchanged, and any genuinely unrecognised entity is left intact so the parser still surfaces a clear error if the input is malformed in some other way.

## Test

Minimal reproducer — fails on `main`, passes with this PR:

```python
from pathlib import Path
import tempfile
from svg_to_pptx import convert_svg_to_slide_shapes

svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">' \
      '<text x="10" y="50">a&nbsp;b&mdash;c</text></svg>'
with tempfile.NamedTemporaryFile(suffix='.svg', mode='w', delete=False) as f:
    f.write(svg); p = f.name
convert_svg_to_slide_shapes(Path(p))
```

I also re-ran the conversion against the original failing 16-slide deck after applying this patch and all 16 slides now convert.

## Scope

Single-file change, ~26 lines, no new dependency (uses stdlib `html.entities.html5`). Behaviour is strictly additive — every input that parsed before still parses identically.
