### PR TITLE
docs(notes_to_audio): drop usage example that always errors out

### DIFF
--- a/skills/ppt-master/scripts/notes_to_audio.py
+++ b/skills/ppt-master/scripts/notes_to_audio.py
@@ -5,7 +5,6 @@ This script uses `edge-tts` for the same cross-platform behavior on macOS,
 Linux, and Windows.
 
 Usage:
-    python3 skills/ppt-master/scripts/notes_to_audio.py <project_path>
     python3 skills/ppt-master/scripts/notes_to_audio.py <project_path> --voice zh-CN-XiaoxiaoNeural
     python3 skills/ppt-master/scripts/notes_to_audio.py --list-common-voices
     python3 skills/ppt-master/scripts/notes_to_audio.py --list-voices --locale zh-CN


### PR DESCRIPTION
## Summary

The docstring of `skills/ppt-master/scripts/notes_to_audio.py` lists four
usage examples. The first one is wrong — running it always exits with an
error, because `--voice` is required by the argparse handler.

## Reproduction

```bash
$ python3 skills/ppt-master/scripts/notes_to_audio.py <project_path>
usage: notes_to_audio.py [-h] [-o OUTPUT] [--voice VOICE] [--rate RATE]
                         [--list-common-voices] [--list-voices]
                         [--locale LOCALE]
                         [project_path]
notes_to_audio.py: error: --voice is required. Run --list-voices --locale <locale> to discover voices ...
```

## Why this matters

The docstring is wired into argparse via
`ArgumentParser(description=__doc__)`, so the misleading example also
shows up verbatim in `--help`. Any user who runs `--help` first (the
obvious thing to do) will then run the example they read and immediately
hit a guaranteed error.

The argparse handler is explicit and intentional about requiring
`--voice` (`notes_to_audio.py` lines 150–155), so the fix is to align
the docstring with the behavior, not the other way around.

## Fix

Remove the first usage line. The three remaining examples are all
valid and already cover the minimal correct invocation:

```diff
 Usage:
-    python3 skills/ppt-master/scripts/notes_to_audio.py <project_path>
     python3 skills/ppt-master/scripts/notes_to_audio.py <project_path> --voice zh-CN-XiaoxiaoNeural
     python3 skills/ppt-master/scripts/notes_to_audio.py --list-common-voices
     python3 skills/ppt-master/scripts/notes_to_audio.py --list-voices --locale zh-CN
```

## Scope

- One file changed, one line removed
- No behavior change (docstring only)
- All other doc references in the repo (`docs/audio-narration.md`,
  `docs/zh/audio-narration.md`, `skills/ppt-master/workflows/generate-audio.md`,
  `skills/ppt-master/references/shared-standards.md`, `scripts/docs/svg-pipeline.md`,
  `scripts/docs/troubleshooting.md`) already include `--voice`, so this
  was the only outlier.

## Test plan
- [x] Ran `python3 skills/ppt-master/scripts/notes_to_audio.py --help`
      after the change and confirmed output is well-formed.
- [x] Reproduced the original error with the unchanged invocation
      (output quoted above).
- [x] `grep -r "notes_to_audio.py"` across the repo to confirm no
      other references show the broken invocation pattern.