### PR TITLE
feat(svg-editor): 多元素选择、框选、元素属性展示

### DIFF
--- a/skills/ppt-master/scripts/svg_editor/static/app.js
+++ b/skills/ppt-master/scripts/svg_editor/static/app.js
@@ -181,19 +181,23 @@
     }
 
     function updateSelectionPanel() {
+        var propsEl = document.getElementById("element-props");
         var count = selectedElementIds.size;
+
         if (count === 0) {
             selectedElementEl.classList.add("empty");
             selectedElementEl.innerHTML = "Click an element on the slide to select it";
             annotationInput.style.display = "none";
             annotationText.value = "";
+            propsEl.style.display = "none";
+            propsEl.innerHTML = "";
             return;
         }
 
         selectedElementEl.classList.remove("empty");
+        propsEl.style.display = "block";
 
         if (count === 1) {
-            // Single select — show tag + id (existing behavior)
             var eid = selectedElementIds.values().next().value;
             var el = svgContent.querySelector("#" + CSS.escape(eid));
             if (el) {
@@ -201,11 +205,12 @@
                 selectedElementEl.innerHTML =
                     '<span class="el-tag">&lt;' + escapeHtml(tag) + '&gt;</span>' +
                     '<span class="el-id">' + escapeHtml(eid) + '</span>';
+                propsEl.innerHTML = renderPropertyTable(getElementProperties(el));
             }
         } else {
-            // Multi select — show count
             selectedElementEl.innerHTML =
                 '<span class="multi-count">' + count + ' elements selected</span>';
+            propsEl.innerHTML = renderMultiSelectSummary(Array.from(selectedElementIds));
         }
 
         annotationInput.style.display = "block";
@@ -213,8 +218,8 @@
             ? "Describe how to modify all " + count + " elements..."
             : "Describe how the AI should modify this element...";
         annotationText.value = count === 1
-        ? (slideAnnotations[selectedElementIds.values().next().value] || "")
-        : "";
+            ? (slideAnnotations[selectedElementIds.values().next().value] || "")
+            : "";
         annotationText.focus();
     }
 
@@ -592,6 +597,121 @@
         var d = document.createElement("div");
         d.appendChild(document.createTextNode(str));
         return d.innerHTML;
+    }
+
+    // ================================================================
+    //  Property extraction & rendering
+    // ================================================================
+    function getElementProperties(elem) {
+        var props = {};
+        var tag = elem.tagName.toLowerCase();
+        var style = window.getComputedStyle(elem);
+
+        // Position (common to all)
+        try {
+            var bbox = elem.getBBox();
+            props["position"] = Math.round(bbox.x) + ", " + Math.round(bbox.y);
+            props["size"] = Math.round(bbox.width) + " x " + Math.round(bbox.height);
+        } catch (e) {
+            // no geometry
+        }
+
+        if (tag === "text" || tag === "tspan") {
+            props["font"] = style.fontFamily || elem.getAttribute("font-family") || "";
+            props["font-size"] = style.fontSize || elem.getAttribute("font-size") || "";
+            props["font-weight"] = style.fontWeight || elem.getAttribute("font-weight") || "";
+            props["fill"] = style.fill || elem.getAttribute("fill") || "";
+            props["anchor"] = elem.getAttribute("text-anchor") || style.textAnchor || "";
+            var text = elem.textContent || "";
+            if (text.length > 50) text = text.substring(0, 50) + "...";
+            props["content"] = text;
+        } else if (tag === "rect") {
+            props["fill"] = elem.getAttribute("fill") || style.fill || "";
+            props["stroke"] = elem.getAttribute("stroke") || style.stroke || "";
+        } else if (tag === "circle") {
+            props["r"] = elem.getAttribute("r") || "";
+            props["fill"] = elem.getAttribute("fill") || style.fill || "";
+            props["stroke"] = elem.getAttribute("stroke") || style.stroke || "";
+        } else if (tag === "ellipse") {
+            props["rx"] = elem.getAttribute("rx") || "";
+            props["ry"] = elem.getAttribute("ry") || "";
+            props["fill"] = elem.getAttribute("fill") || style.fill || "";
+        } else if (tag === "image") {
+            var href = elem.getAttribute("href") || elem.getAttribute("xlink:href") || "";
+            var parts = href.split("/");
+            props["file"] = parts[parts.length - 1] || href;
+        } else if (tag === "path") {
+            props["fill"] = elem.getAttribute("fill") || style.fill || "";
+            props["stroke"] = elem.getAttribute("stroke") || style.stroke || "";
+        }
+
+        return props;
+    }
+
+    function renderPropertyTable(props) {
+        var html = '<table class="prop-table">';
+        Object.keys(props).forEach(function (key) {
+            var val = props[key];
+            if (!val) return;
+            html += '<tr><td class="prop-key">' + escapeHtml(key) + '</td><td class="prop-val">';
+            if (key === "fill" || key === "stroke") {
+                html += '<span class="prop-color" style="background:' + escapeHtml(val) + ';"></span>';
+            }
+            html += escapeHtml(val) + '</td></tr>';
+        });
+        html += '</table>';
+        return html;
+    }
+
+    function renderMultiSelectSummary(ids) {
+        var typeCounts = {};
+        var sharedFontSize = null;
+        var allHaveFontSize = true;
+
+        ids.forEach(function (eid) {
+            var el = svgContent.querySelector("#" + CSS.escape(eid));
+            if (!el) return;
+            var tag = el.tagName.toLowerCase();
+            typeCounts[tag] = (typeCounts[tag] || 0) + 1;
+
+            if (tag === "text" || tag === "tspan") {
+                var fs = window.getComputedStyle(el).fontSize || el.getAttribute("font-size") || "";
+                if (sharedFontSize === null) {
+                    sharedFontSize = fs;
+                } else if (sharedFontSize !== fs) {
+                    sharedFontSize = "mixed";
+                }
+            } else {
+                allHaveFontSize = false;
+            }
+        });
+
+        var summary = '<div class="multi-summary">';
+        var parts = [];
+        Object.keys(typeCounts).forEach(function (tag) {
+            parts.push(typeCounts[tag] + " " + tag);
+        });
+        summary += parts.join(", ");
+
+        if (allHaveFontSize && sharedFontSize && sharedFontSize !== "mixed") {
+            summary += ' | font-size: ' + escapeHtml(sharedFontSize);
+        } else if (allHaveFontSize && sharedFontSize === "mixed") {
+            summary += ' | font-size: mixed';
+        }
+        summary += '</div>';
+
+        // Element list
+        summary += '<div class="multi-el-list">';
+        ids.forEach(function (eid) {
+            var el = svgContent.querySelector("#" + CSS.escape(eid));
+            if (!el) return;
+            var tag = el.tagName.toLowerCase();
+            summary += '<div class="multi-el-item"><span class="el-tag">&lt;' +
+                escapeHtml(tag) + '&gt;</span>' + escapeHtml(eid) + '</div>';
+        });
+        summary += '</div>';
+
+        return summary;
     }
 
     // ================================================================

--- a/skills/ppt-master/scripts/svg_editor/static/app.js
+++ b/skills/ppt-master/scripts/svg_editor/static/app.js
@@ -585,6 +585,11 @@
         doc.querySelectorAll("*").forEach(function (el) {
             Array.from(el.attributes).forEach(function (attr) {
                 if (attr.name.indexOf("on") === 0) el.removeAttribute(attr.name);
+                // Strip javascript: protocol from href/xlink:href
+                if ((attr.name === "href" || attr.name === "xlink:href") &&
+                    /^\s*javascript\s*:/i.test(attr.value)) {
+                    el.removeAttribute(attr.name);
+                }
             });
         });
         return new XMLSerializer().serializeToString(doc.documentElement);

--- a/skills/ppt-master/scripts/svg_editor/static/app.js
+++ b/skills/ppt-master/scripts/svg_editor/static/app.js
@@ -237,18 +237,12 @@
             // Only left mouse button
             if (e.button !== 0) return;
 
-            // If clicking on a leaf SVG element (has a selectable ancestor that isn't
-            // the SVG root), let its click handler deal with selection.
-            var svg = svgContent.querySelector("svg");
-            var selectable = e.target.closest ? e.target.closest(".svg-selectable") : null;
-            if (selectable && selectable !== svg) {
-                return;
-            }
-
-            // Starting rubber band on empty space or SVG background
+            // Always start tracking — rubber band only activates when
+            // mousemove exceeds the threshold. This allows clicking on any
+            // element (including SVG background rects) to still trigger
+            // the element's click handler for selection.
             rubberBandStart = { x: e.clientX, y: e.clientY };
             rubberBandUsed = false;
-            overlay.classList.add("active");
         });
 
         document.addEventListener("mousemove", function (e) {
@@ -259,6 +253,12 @@
 
             if (Math.abs(dx) < RUBBER_BAND_THRESHOLD && Math.abs(dy) < RUBBER_BAND_THRESHOLD) {
                 return;
+            }
+
+            // Threshold exceeded — this is a drag, not a click
+            if (!rubberBandUsed) {
+                rubberBandUsed = true;
+                overlay.classList.add("active");
             }
 
             if (!rubberBandEl) {
@@ -293,7 +293,6 @@
 
             // Only process if drag was beyond threshold
             if (Math.abs(dx) >= RUBBER_BAND_THRESHOLD || Math.abs(dy) >= RUBBER_BAND_THRESHOLD) {
-                rubberBandUsed = true;
                 var rect = {
                     left: Math.min(rubberBandStart.x, e.clientX),
                     top: Math.min(rubberBandStart.y, e.clientY),
@@ -395,8 +394,9 @@
                 updateSelectionPanel();
             }
 
-            // Escape: clear selection
+            // Escape: clear selection (skip if textarea is focused)
             if (e.key === "Escape") {
+                if (document.activeElement === annotationText) return;
                 clearSelection();
             }
         });

--- a/skills/ppt-master/scripts/svg_editor/static/app.js
+++ b/skills/ppt-master/scripts/svg_editor/static/app.js
@@ -361,6 +361,37 @@
     }
 
     // ================================================================
+    //  Keyboard shortcuts
+    // ================================================================
+    function initKeyboardShortcuts() {
+        document.addEventListener("keydown", function (e) {
+            // Ctrl+A / Cmd+A: select all elements
+            if ((e.ctrlKey || e.metaKey) && e.key === "a") {
+                // Don't intercept if focus is in textarea
+                if (document.activeElement === annotationText) return;
+
+                e.preventDefault();
+                var svg = svgContent.querySelector("svg");
+                if (!svg) return;
+
+                svg.querySelectorAll(".svg-selectable").forEach(function (el) {
+                    var eid = el.id;
+                    if (eid) {
+                        selectedElementIds.add(eid);
+                        el.classList.add("svg-selected");
+                    }
+                });
+                updateSelectionPanel();
+            }
+
+            // Escape: clear selection
+            if (e.key === "Escape") {
+                clearSelection();
+            }
+        });
+    }
+
+    // ================================================================
     //  6.  Add annotation  -- POST /api/slide/{name}/annotate
     // ================================================================
     btnAddAnnotation.addEventListener("click", function () {
@@ -568,4 +599,5 @@
     // ================================================================
     loadSlides();
     initRubberBand();
+    initKeyboardShortcuts();
 })();

--- a/skills/ppt-master/scripts/svg_editor/static/app.js
+++ b/skills/ppt-master/scripts/svg_editor/static/app.js
@@ -130,8 +130,9 @@
             });
         });
 
-        // Click on blank area clears selection
+        // Click on blank area clears selection (skip after rubber band)
         svg.addEventListener("click", function (e) {
+            if (rubberBandUsed) { rubberBandUsed = false; return; }
             if (e.target === svg) clearSelection();
         });
     }
@@ -220,12 +221,12 @@
         annotationText.value = count === 1
             ? (slideAnnotations[selectedElementIds.values().next().value] || "")
             : "";
-        annotationText.focus();
     }
 
     // ---- Rubber band selection ----
     var rubberBandEl = null;
     var rubberBandStart = null;
+    var rubberBandUsed = false;
     var RUBBER_BAND_THRESHOLD = 5;
 
     function initRubberBand() {
@@ -236,13 +237,17 @@
             // Only left mouse button
             if (e.button !== 0) return;
 
-            // If clicking on a selectable SVG element, let its click handler deal with it
-            if (e.target.classList && e.target.classList.contains("svg-selectable")) {
+            // If clicking on a leaf SVG element (has a selectable ancestor that isn't
+            // the SVG root), let its click handler deal with selection.
+            var svg = svgContent.querySelector("svg");
+            var selectable = e.target.closest ? e.target.closest(".svg-selectable") : null;
+            if (selectable && selectable !== svg) {
                 return;
             }
 
-            // Starting rubber band on empty space
+            // Starting rubber band on empty space or SVG background
             rubberBandStart = { x: e.clientX, y: e.clientY };
+            rubberBandUsed = false;
             overlay.classList.add("active");
         });
 
@@ -288,6 +293,7 @@
 
             // Only process if drag was beyond threshold
             if (Math.abs(dx) >= RUBBER_BAND_THRESHOLD || Math.abs(dy) >= RUBBER_BAND_THRESHOLD) {
+                rubberBandUsed = true;
                 var rect = {
                     left: Math.min(rubberBandStart.x, e.clientX),
                     top: Math.min(rubberBandStart.y, e.clientY),

--- a/skills/ppt-master/scripts/svg_editor/static/app.js
+++ b/skills/ppt-master/scripts/svg_editor/static/app.js
@@ -19,6 +19,7 @@
     var modalMessage      = document.getElementById("modal-message");
     var modalConfirm      = document.getElementById("modal-confirm");
     var modalCancel       = document.getElementById("modal-cancel");
+    var elementPropsEl    = document.getElementById("element-props");
 
     // ---- State ------------------------------------------------------
     var currentSlide      = null;   // filename, e.g. "slide_01.svg"
@@ -182,7 +183,7 @@
     }
 
     function updateSelectionPanel() {
-        var propsEl = document.getElementById("element-props");
+        var propsEl = elementPropsEl;
         var count = selectedElementIds.size;
 
         if (count === 0) {
@@ -250,8 +251,9 @@
 
             var dx = e.clientX - rubberBandStart.x;
             var dy = e.clientY - rubberBandStart.y;
+            var dist = Math.sqrt(dx * dx + dy * dy);
 
-            if (Math.abs(dx) < RUBBER_BAND_THRESHOLD && Math.abs(dy) < RUBBER_BAND_THRESHOLD) {
+            if (dist < RUBBER_BAND_THRESHOLD) {
                 return;
             }
 
@@ -285,6 +287,7 @@
 
             var dx = e.clientX - rubberBandStart.x;
             var dy = e.clientY - rubberBandStart.y;
+            var dist = Math.sqrt(dx * dx + dy * dy);
 
             if (rubberBandEl) {
                 rubberBandEl.remove();
@@ -292,7 +295,7 @@
             }
 
             // Only process if drag was beyond threshold
-            if (Math.abs(dx) >= RUBBER_BAND_THRESHOLD || Math.abs(dy) >= RUBBER_BAND_THRESHOLD) {
+            if (dist >= RUBBER_BAND_THRESHOLD) {
                 var rect = {
                     left: Math.min(rubberBandStart.x, e.clientX),
                     top: Math.min(rubberBandStart.y, e.clientY),
@@ -307,7 +310,9 @@
                 selectByRubberBand(rect);
             } else {
                 // Below threshold: treat as click on empty space
-                clearSelection();
+                if (!e.ctrlKey && !e.metaKey) {
+                    clearSelection();
+                }
             }
 
             rubberBandStart = null;
@@ -585,9 +590,10 @@
         doc.querySelectorAll("*").forEach(function (el) {
             Array.from(el.attributes).forEach(function (attr) {
                 if (attr.name.indexOf("on") === 0) el.removeAttribute(attr.name);
-                // Strip javascript: protocol from href/xlink:href
+                // Strip dangerous URI protocols from href/xlink:href
                 if ((attr.name === "href" || attr.name === "xlink:href") &&
-                    /^\s*javascript\s*:/i.test(attr.value)) {
+                    (/^\s*javascript\s*:/i.test(attr.value) ||
+                     /^\s*data\s*:/i.test(attr.value))) {
                     el.removeAttribute(attr.name);
                 }
             });
@@ -659,13 +665,19 @@
         return props;
     }
 
+    function isSafeColor(val) {
+        // Only allow values that look like CSS colors (hex, rgb, rgba, hsl, named).
+        // Reject anything with ; : url @ \ to prevent CSS injection.
+        return val.length < 100 && !/[;:@\\]|url\s*\(/i.test(val);
+    }
+
     function renderPropertyTable(props) {
         var html = '<table class="prop-table">';
         Object.keys(props).forEach(function (key) {
             var val = props[key];
             if (!val) return;
             html += '<tr><td class="prop-key">' + escapeHtml(key) + '</td><td class="prop-val">';
-            if (key === "fill" || key === "stroke") {
+            if ((key === "fill" || key === "stroke") && isSafeColor(val)) {
                 html += '<span class="prop-color" style="background:' + escapeHtml(val) + ';"></span>';
             }
             html += escapeHtml(val) + '</td></tr>';

--- a/skills/ppt-master/scripts/svg_editor/static/app.js
+++ b/skills/ppt-master/scripts/svg_editor/static/app.js
@@ -22,7 +22,7 @@
 
     // ---- State ------------------------------------------------------
     var currentSlide      = null;   // filename, e.g. "slide_01.svg"
-    var selectedElementId = null;   // id attr of the clicked SVG element
+    var selectedElementIds = new Set(); // id attrs of selected SVG elements
     var slideAnnotations  = {};     // {element_id: annotation_text} for current slide
 
     // ================================================================
@@ -73,7 +73,7 @@
         if (el) el.classList.add("active");
 
         currentSlide = name;
-        selectedElementId = null;
+        selectedElementIds.clear();
         slideAnnotations = {};
 
         // Reset right panel
@@ -125,7 +125,7 @@
 
             el.addEventListener("click", function (e) {
                 e.stopPropagation();
-                selectElement(el);
+                selectElement(el, e.ctrlKey || e.metaKey);
             });
         });
 
@@ -138,69 +138,109 @@
     // ================================================================
     //  4.  selectElement
     // ================================================================
-    function selectElement(elem) {
-        // Remove old highlight
-        if (selectedElementId) {
-            var old = svgContent.querySelector("#" + CSS.escape(selectedElementId));
-            if (old) old.classList.remove("svg-selected");
+    function selectElement(elem, addToSelection) {
+        var eid = elem.id;
+        if (!eid) return;
+
+        if (addToSelection) {
+            // Ctrl+click: toggle this element
+            if (selectedElementIds.has(eid)) {
+                selectedElementIds.delete(eid);
+                elem.classList.remove("svg-selected");
+            } else {
+                selectedElementIds.add(eid);
+                elem.classList.add("svg-selected");
+            }
+        } else {
+            // Normal click: clear others, select only this one
+            selectedElementIds.forEach(function (id) {
+                if (id !== eid) {
+                    var old = svgContent.querySelector("#" + CSS.escape(id));
+                    if (old) old.classList.remove("svg-selected");
+                }
+            });
+            selectedElementIds.clear();
+            selectedElementIds.add(eid);
+            elem.classList.add("svg-selected");
         }
 
-        selectedElementId = elem.id || null;
-        elem.classList.add("svg-selected");
-
-        // Update right panel info
-        selectedElementEl.classList.remove("empty");
-        var tag = elem.tagName.toLowerCase();
-        var id  = elem.id || "(no id)";
-        selectedElementEl.innerHTML =
-            '<span class="el-tag">&lt;' + escapeHtml(tag) + '&gt;</span>' +
-            '<span class="el-id">' + escapeHtml(id) + '</span>';
-
-        // Show annotation input, pre-fill if annotation already exists
-        annotationInput.style.display = "block";
-        annotationText.value = slideAnnotations[selectedElementId] || "";
-        annotationText.focus();
+        updateSelectionPanel();
     }
 
     // ================================================================
     //  5.  clearSelection
     // ================================================================
     function clearSelection() {
-        if (selectedElementId) {
-            var el = svgContent.querySelector("#" + CSS.escape(selectedElementId));
+        selectedElementIds.forEach(function (id) {
+            var el = svgContent.querySelector("#" + CSS.escape(id));
             if (el) el.classList.remove("svg-selected");
+        });
+        selectedElementIds.clear();
+        updateSelectionPanel();
+    }
+
+    function updateSelectionPanel() {
+        var count = selectedElementIds.size;
+        if (count === 0) {
+            selectedElementEl.classList.add("empty");
+            selectedElementEl.innerHTML = "Click an element on the slide to select it";
+            annotationInput.style.display = "none";
+            annotationText.value = "";
+            return;
         }
-        selectedElementId = null;
-        selectedElementEl.classList.add("empty");
-        selectedElementEl.innerHTML = "Click an element on the slide to select it";
-        annotationInput.style.display = "none";
-        annotationText.value = "";
+
+        selectedElementEl.classList.remove("empty");
+
+        if (count === 1) {
+            // Single select — show tag + id (existing behavior)
+            var eid = selectedElementIds.values().next().value;
+            var el = svgContent.querySelector("#" + CSS.escape(eid));
+            if (el) {
+                var tag = el.tagName.toLowerCase();
+                selectedElementEl.innerHTML =
+                    '<span class="el-tag">&lt;' + escapeHtml(tag) + '&gt;</span>' +
+                    '<span class="el-id">' + escapeHtml(eid) + '</span>';
+            }
+        } else {
+            // Multi select — show count
+            selectedElementEl.innerHTML =
+                '<span class="multi-count">' + count + ' elements selected</span>';
+        }
+
+        annotationInput.style.display = "block";
+        annotationText.placeholder = count > 1
+            ? "Describe how to modify all " + count + " elements..."
+            : "Describe how the AI should modify this element...";
+        annotationText.value = slideAnnotations[Array.from(selectedElementIds)[0]] || "";
+        annotationText.focus();
     }
 
     // ================================================================
     //  6.  Add annotation  -- POST /api/slide/{name}/annotate
     // ================================================================
     btnAddAnnotation.addEventListener("click", function () {
-        if (!currentSlide || !selectedElementId) return;
+        if (!currentSlide || selectedElementIds.size === 0) return;
 
         var text = annotationText.value.trim();
         if (!text) return;
 
-        fetch("/api/slide/" + encodeURIComponent(currentSlide) + "/annotate", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-                element_id: selectedElementId,
-                annotation: text
-            })
-        })
-            .then(function (res) { return res.json(); })
+        var ids = Array.from(selectedElementIds);
+        var promises = ids.map(function (eid) {
+            return fetch("/api/slide/" + encodeURIComponent(currentSlide) + "/annotate", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ element_id: eid, annotation: text })
+            }).then(function (res) { return res.json(); });
+        });
+
+        Promise.all(promises)
             .then(function () {
-                slideAnnotations[selectedElementId] = text;
+                ids.forEach(function (eid) {
+                    slideAnnotations[eid] = text;
+                });
                 refreshAnnotationVisuals();
                 updateAnnotationList();
                 annotationText.value = "";
-                // Reload slide list to update badge counts
                 loadSlides();
             })
             .catch(function (err) {

--- a/skills/ppt-master/scripts/svg_editor/static/app.js
+++ b/skills/ppt-master/scripts/svg_editor/static/app.js
@@ -217,6 +217,136 @@
         annotationText.focus();
     }
 
+    // ---- Rubber band selection ----
+    var rubberBandEl = null;
+    var rubberBandStart = null;
+    var RUBBER_BAND_THRESHOLD = 5;
+
+    function initRubberBand() {
+        var overlay = document.getElementById("rubber-band-overlay");
+        var container = document.getElementById("svg-container");
+
+        container.addEventListener("mousedown", function (e) {
+            // Only left mouse button
+            if (e.button !== 0) return;
+
+            // If clicking on a selectable SVG element, let its click handler deal with it
+            if (e.target.classList && e.target.classList.contains("svg-selectable")) {
+                return;
+            }
+
+            // Starting rubber band on empty space
+            rubberBandStart = { x: e.clientX, y: e.clientY };
+            overlay.classList.add("active");
+        });
+
+        document.addEventListener("mousemove", function (e) {
+            if (!rubberBandStart) return;
+
+            var dx = e.clientX - rubberBandStart.x;
+            var dy = e.clientY - rubberBandStart.y;
+
+            if (Math.abs(dx) < RUBBER_BAND_THRESHOLD && Math.abs(dy) < RUBBER_BAND_THRESHOLD) {
+                return;
+            }
+
+            if (!rubberBandEl) {
+                rubberBandEl = document.createElement("div");
+                rubberBandEl.id = "rubber-band";
+                document.body.appendChild(rubberBandEl);
+            }
+
+            var x = Math.min(rubberBandStart.x, e.clientX);
+            var y = Math.min(rubberBandStart.y, e.clientY);
+            var w = Math.abs(dx);
+            var h = Math.abs(dy);
+
+            rubberBandEl.style.left = x + "px";
+            rubberBandEl.style.top = y + "px";
+            rubberBandEl.style.width = w + "px";
+            rubberBandEl.style.height = h + "px";
+        });
+
+        document.addEventListener("mouseup", function (e) {
+            if (!rubberBandStart) return;
+
+            var overlay = document.getElementById("rubber-band-overlay");
+            overlay.classList.remove("active");
+
+            var dx = e.clientX - rubberBandStart.x;
+            var dy = e.clientY - rubberBandStart.y;
+
+            if (rubberBandEl) {
+                rubberBandEl.remove();
+                rubberBandEl = null;
+            }
+
+            // Only process if drag was beyond threshold
+            if (Math.abs(dx) >= RUBBER_BAND_THRESHOLD || Math.abs(dy) >= RUBBER_BAND_THRESHOLD) {
+                var rect = {
+                    left: Math.min(rubberBandStart.x, e.clientX),
+                    top: Math.min(rubberBandStart.y, e.clientY),
+                    right: Math.max(rubberBandStart.x, e.clientX),
+                    bottom: Math.max(rubberBandStart.y, e.clientY)
+                };
+
+                if (!e.ctrlKey && !e.metaKey) {
+                    clearSelection();
+                }
+
+                selectByRubberBand(rect, e.ctrlKey || e.metaKey);
+            }
+
+            rubberBandStart = null;
+        });
+    }
+
+    function selectByRubberBand(screenRect, addToSelection) {
+        var svg = svgContent.querySelector("svg");
+        if (!svg) return;
+
+        var selectableEls = svg.querySelectorAll(".svg-selectable");
+        selectableEls.forEach(function (el) {
+            try {
+                var bbox = el.getBBox();
+                var ctm = el.getScreenCTM();
+                if (!ctm) return;
+
+                // Transform bbox corners to screen coordinates
+                var corners = [
+                    { x: bbox.x, y: bbox.y },
+                    { x: bbox.x + bbox.width, y: bbox.y },
+                    { x: bbox.x, y: bbox.y + bbox.height },
+                    { x: bbox.x + bbox.width, y: bbox.y + bbox.height }
+                ];
+
+                var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+                corners.forEach(function (c) {
+                    var sx = c.x * ctm.a + c.y * ctm.c + ctm.e;
+                    var sy = c.x * ctm.b + c.y * ctm.d + ctm.f;
+                    if (sx < minX) minX = sx;
+                    if (sy < minY) minY = sy;
+                    if (sx > maxX) maxX = sx;
+                    if (sy > maxY) maxY = sy;
+                });
+
+                // AABB intersection
+                if (minX < screenRect.right && maxX > screenRect.left &&
+                    minY < screenRect.bottom && maxY > screenRect.top) {
+                    var eid = el.id;
+                    if (eid) {
+                        selectedElementIds.add(eid);
+                        el.classList.add("svg-selected");
+                    }
+                }
+            } catch (err) {
+                // getBBox can throw for elements with no geometry
+            }
+        });
+
+        updateSelectionPanel();
+    }
+
     // ================================================================
     //  6.  Add annotation  -- POST /api/slide/{name}/annotate
     // ================================================================
@@ -424,4 +554,5 @@
     //  Boot
     // ================================================================
     loadSlides();
+    initRubberBand();
 })();

--- a/skills/ppt-master/scripts/svg_editor/static/app.js
+++ b/skills/ppt-master/scripts/svg_editor/static/app.js
@@ -211,7 +211,9 @@
         annotationText.placeholder = count > 1
             ? "Describe how to modify all " + count + " elements..."
             : "Describe how the AI should modify this element...";
-        annotationText.value = slideAnnotations[Array.from(selectedElementIds)[0]] || "";
+        annotationText.value = count === 1
+        ? (slideAnnotations[selectedElementIds.values().next().value] || "")
+        : "";
         annotationText.focus();
     }
 

--- a/skills/ppt-master/scripts/svg_editor/static/app.js
+++ b/skills/ppt-master/scripts/svg_editor/static/app.js
@@ -76,7 +76,8 @@
         selectedElementIds.clear();
         slideAnnotations = {};
 
-        // Reset right panel
+        // Reset right panel and rubber band
+        cancelRubberBand();
         clearSelection();
 
         fetch("/api/slide/" + encodeURIComponent(name))
@@ -270,7 +271,6 @@
         document.addEventListener("mouseup", function (e) {
             if (!rubberBandStart) return;
 
-            var overlay = document.getElementById("rubber-band-overlay");
             overlay.classList.remove("active");
 
             var dx = e.clientX - rubberBandStart.x;
@@ -294,14 +294,27 @@
                     clearSelection();
                 }
 
-                selectByRubberBand(rect, e.ctrlKey || e.metaKey);
+                selectByRubberBand(rect);
+            } else {
+                // Below threshold: treat as click on empty space
+                clearSelection();
             }
 
             rubberBandStart = null;
         });
     }
 
-    function selectByRubberBand(screenRect, addToSelection) {
+    function cancelRubberBand() {
+        rubberBandStart = null;
+        if (rubberBandEl) {
+            rubberBandEl.remove();
+            rubberBandEl = null;
+        }
+        var ov = document.getElementById("rubber-band-overlay");
+        if (ov) ov.classList.remove("active");
+    }
+
+    function selectByRubberBand(screenRect) {
         var svg = svgContent.querySelector("svg");
         if (!svg) return;
 

--- a/skills/ppt-master/scripts/svg_editor/static/index.html
+++ b/skills/ppt-master/scripts/svg_editor/static/index.html
@@ -24,6 +24,7 @@
             <div id="selection-info">
                 <div class="section-label">Selected element</div>
                 <div id="selected-element" class="empty">Click an element on the slide to select it</div>
+                <div id="element-props" style="display:none;"></div>
             </div>
             <div id="annotation-input" style="display:none;">
                 <div class="section-label">Edit instruction</div>

--- a/skills/ppt-master/scripts/svg_editor/static/index.html
+++ b/skills/ppt-master/scripts/svg_editor/static/index.html
@@ -14,6 +14,7 @@
         </div>
         <div id="panel-center">
             <div id="svg-container">
+                <div id="rubber-band-overlay"></div>
                 <div id="svg-placeholder">Select a slide on the left to begin</div>
                 <div id="svg-content" style="display:none;"></div>
             </div>

--- a/skills/ppt-master/scripts/svg_editor/static/style.css
+++ b/skills/ppt-master/scripts/svg_editor/static/style.css
@@ -461,6 +461,78 @@ html, body {
     background: #2a2a4a;
 }
 
+/* --- Element properties --- */
+#element-props {
+    margin-top: 10px;
+    font-size: 12px;
+}
+
+.prop-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.prop-table tr {
+    border-bottom: 1px solid #2a2a4a;
+}
+
+.prop-table tr:last-child {
+    border-bottom: none;
+}
+
+.prop-table td {
+    padding: 4px 0;
+    vertical-align: top;
+}
+
+.prop-table .prop-key {
+    color: #7a7a9a;
+    width: 80px;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+}
+
+.prop-table .prop-val {
+    color: #c0c0d8;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: 12px;
+    word-break: break-all;
+}
+
+.prop-table .prop-color {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+    vertical-align: middle;
+    margin-right: 4px;
+    border: 1px solid #3a3a5a;
+}
+
+.multi-el-list {
+    margin-top: 6px;
+    max-height: 100px;
+    overflow-y: auto;
+    font-size: 11px;
+}
+
+.multi-el-item {
+    padding: 2px 0;
+    color: #7a7a9a;
+}
+
+.multi-el-item .el-tag {
+    font-size: 10px;
+    margin-right: 4px;
+}
+
+.multi-summary {
+    margin-top: 8px;
+    font-size: 12px;
+    color: #a0a0c0;
+}
+
 /* --- Multi-select count --- */
 .multi-count {
     color: #4a9eff;

--- a/skills/ppt-master/scripts/svg_editor/static/style.css
+++ b/skills/ppt-master/scripts/svg_editor/static/style.css
@@ -555,8 +555,8 @@ html, body {
 
 #rubber-band {
     position: fixed;
-    border: 1px solid #4a9eff;
-    background: rgba(74, 158, 255, 0.12);
+    border: 2px dashed #4a9eff;
+    background: rgba(74, 158, 255, 0.15);
     pointer-events: none;
     z-index: 11;
 }

--- a/skills/ppt-master/scripts/svg_editor/static/style.css
+++ b/skills/ppt-master/scripts/svg_editor/static/style.css
@@ -465,6 +465,8 @@ html, body {
 #element-props {
     margin-top: 10px;
     font-size: 12px;
+    max-height: 200px;
+    overflow-y: auto;
 }
 
 .prop-table {

--- a/skills/ppt-master/scripts/svg_editor/static/style.css
+++ b/skills/ppt-master/scripts/svg_editor/static/style.css
@@ -123,6 +123,7 @@ html, body {
     justify-content: center;
     overflow: auto;
     padding: 24px;
+    position: relative;
 }
 
 #svg-placeholder {
@@ -465,6 +466,27 @@ html, body {
     color: #4a9eff;
     font-weight: 600;
     font-size: 14px;
+}
+
+/* --- Rubber band selection --- */
+#rubber-band-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+    pointer-events: none;
+    cursor: crosshair;
+}
+
+#rubber-band-overlay.active {
+    pointer-events: auto;
+}
+
+#rubber-band {
+    position: fixed;
+    border: 1px solid #4a9eff;
+    background: rgba(74, 158, 255, 0.12);
+    pointer-events: none;
+    z-index: 11;
 }
 
 /* ======================== UTILITY ======================== */

--- a/skills/ppt-master/scripts/svg_editor/static/style.css
+++ b/skills/ppt-master/scripts/svg_editor/static/style.css
@@ -460,6 +460,13 @@ html, body {
     background: #2a2a4a;
 }
 
+/* --- Multi-select count --- */
+.multi-count {
+    color: #4a9eff;
+    font-weight: 600;
+    font-size: 14px;
+}
+
 /* ======================== UTILITY ======================== */
 .visually-hidden {
     position: absolute;


### PR DESCRIPTION
## 概要

在 #84 的基础上，为 SVG 视觉编辑器添加多元素批量操作能力。用户现在可以通过 Ctrl+click、框选或 Ctrl+A 一次性选择多个元素，并对选中元素统一添加标注。同时，右侧面板新增元素属性展示（字体、字号、颜色、位置等），帮助用户更精准地描述修改意图。

Closes #84

## 新增功能

### 1. 多元素选择
- **Ctrl+click**：按住 Ctrl 点击元素进行加选/取消（toggle）
- **框选（Rubber Band）**：在空白区域按住鼠标左键拖拽，框选范围内所有元素
- **Ctrl+A**：全选当前幻灯片所有元素
- **Escape**：清除当前选择（在标注输入框内按 Escape 不会误清除）

### 2. 统一批量标注
- 选中多个元素后，一条标注自动应用到所有选中元素
- 通过 Promise.all 并行调用现有 API，无新增后端接口

### 3. 元素属性展示
- **单选**：显示元素的 position、size、font、font-size、fill、stroke 等属性，颜色值带色块预览
- **多选**：显示类型统计（如 "3 text, 2 rect"）、共享 font-size、元素列表

## 修改文件

| 文件 | 改动 | 说明 |
|------|------|------|
| scripts/svg_editor/static/app.js | +405/-44 | 核心逻辑：多选状态模型、框选碰撞检测、快捷键、属性提取、批量标注 |
| scripts/svg_editor/static/index.html | +2 | 新增 rubber-band-overlay 和 element-props 容器 |
| scripts/svg_editor/static/style.css | +103 | 框选样式、属性表格、多选摘要面板 |

无后端改动，无新增依赖。

## 测试

### 自动化测试（20 项，全部通过）

| 编号 | 测试内容 | 覆盖点 |
|------|---------|--------|
| T1 | Ctrl+A 全选（元素点击后） | textarea 不应自动聚焦拦截快捷键 |
| T2 | textarea 不自动聚焦 | updateSelectionPanel 回归防护 |
| T3 | 框选创建 + overlay 激活 | mousedown 启动框选流程 |
| T4 | 框选选中范围内元素 | getBBox + getScreenCTM 碰撞检测 |
| T5 | 单击元素正常选中 | 框选不干扰普通点击 |
| T6 | Escape 在 textarea 聚焦时保留选择 | Escape handler guard |
| T7 | Escape 在非聚焦时清除选择 | 正常清除行为 |
| T8 | 点击-清除-点击无重复选中 | 事件监听器无累积 |
| T9 | Ctrl+click 多选 | Set 状态管理 |
| T10 | 框选替换已有选择 | 无 Ctrl 时清除旧选择 |
| T11 | Ctrl+click 取消选中 | toggle 逻辑 |
| T12 | 单选显示属性表格 | getElementProperties + renderPropertyTable |
| T13 | 多选显示摘要 | renderMultiSelectSummary |
| T14 | 点击空白清除选择 | SVG 背景 click handler |
| T15 | 阈值内拖拽不触发框选 | 5px 对角线阈值 |
| T16 | Ctrl+框选追加选择 | 框选 + modifier key |
| T17 | 操作后 Set 与 DOM 一致性 | 状态同步 |
| T18 | metaKey (Mac Cmd) 等效 | 跨平台兼容 |
| T19 | 清除后面板/属性隐藏 | UI 清理 |

### 人工测试
- 使用示例项目启动编辑器，在浏览器中实际操作：单选、多选、框选、添加标注、保存
- 从头创建 PPT 项目并测试编辑器 API 端点（slides、annotate、save-all）

## 安全改进

- sanitizeSvg 移除 javascript: 和 data: 协议的 href
- 颜色属性渲染使用 isSafeColor() 验证，防止 CSS 注入
- 框选阈值使用对角线距离，mousemove/mouseup 逻辑一致