### PR TITLE
feat: 添加导出 prompt 手动生成模式 (Path C)

### DIFF
--- a/skills/ppt-master/SKILL.md
+++ b/skills/ppt-master/SKILL.md
@@ -211,6 +211,22 @@ python3 ${SKILL_DIR}/scripts/analyze_images.py <project_path>/images
 
 > **Trigger**: At least one row in the resource list has `Acquire Via: ai` and/or `Acquire Via: web`. If every row is `user` or `placeholder`, skip to Step 6.
 
+> **Image strategy pre-check**:
+>
+> If the resource list contains rows with `Acquire Via: ai` AND the user
+> has NOT provided those images AND `IMAGE_BACKEND` is not configured in
+> environment or `.env`:
+>
+> Ask the user once (do not repeat):
+>   "图片生成 API 未配置。对于需要 AI 生成的图片，你想怎么处理？"
+>   1. 网络搜索 — 从免费图库自动搜索相关图片（零配置，立即可用）
+>   2. 导出 prompt 手动生成 — 我把每张图的 prompt 导出成文件，你拿去 ChatGPT / Midjourney 等工具生成后放回来
+>
+> - If user chooses 1: change those rows' `Acquire Via` to `web`, then proceed with the `web` path below
+> - If user chooses 2: keep `Acquire Via: ai`, load `image-generator.md`, and use Path C (prompt export)
+>
+> If `IMAGE_BACKEND` IS configured OR user provided all images: skip this check.
+
 **Always load the common framework**:
 
 ```

--- a/skills/ppt-master/references/image-generator.md
+++ b/skills/ppt-master/references/image-generator.md
@@ -284,6 +284,8 @@ python3 ${SKILL_DIR}/scripts/dry_run_export.py <project_path>
 5. Verify all expected files exist in `project/images/`
 6. Mark status as `Generated` for files that exist, `Needs-Manual` for missing ones
 
+> ⚠️ All `Generated` images MUST be used in the Executor phase. Do not skip any verified image — include every one in the SVG output per the resource list.
+
 **Fallback from Path A**: If `image_gen.py` fails (bad key, network error), ask: "要不要切换到导出 prompt 手动生成模式？" If yes, run `dry_run_export.py` instead.
 
 #### AI-specific Failure Handling (extends image-base.md §5)

--- a/skills/ppt-master/references/image-generator.md
+++ b/skills/ppt-master/references/image-generator.md
@@ -201,8 +201,9 @@ For each image with `Acquire Via: ai` and `Status: Pending`:
 |---------|------|-----------|
 | **Default** — no explicit override from the user | **Path A**: `image_gen.py` CLI | Uses `.env` `IMAGE_BACKEND` configuration |
 | **User explicitly names the host's native image tool** (e.g. "use Codex's built-in image generation", "use Antigravity's image tool") | **Path B**: Host-native tool | Agent invokes the host's own image generation capability and saves outputs to `project/images/` |
+| **User chose "导出 prompt 手动生成" in Step 5 pre-check** OR explicitly requests manual generation | **Path C**: prompt export | `python3 ${SKILL_DIR}/scripts/dry_run_export.py <project_path>` — exports prompts to `.txt` files; user generates externally |
 
-Agent must NOT silently switch paths based on perceived host capability. Path B is triggered only by an explicit user instruction for this project or this generation batch. In the absence of such instruction, Path A is the unconditional default.
+Agent must NOT silently switch paths based on perceived host capability. Path B is triggered only by an explicit user instruction for this project or this generation batch. Path C is triggered when the user has no image generation API key and chooses to export prompts for manual generation.
 
 #### Path A — `image_gen.py` CLI (Default)
 
@@ -259,6 +260,31 @@ Triggered only when the user explicitly asks the skill to use the host's built-i
 - Agent invokes the host's native image tool directly; prompts come from the same `image_prompts.md`
 - Outputs **must** land at `project/images/<filename-from-resource-list>` with dimensions matching the Image Resource List
 - Executor downstream is path-agnostic — no spec change required between Path A and Path B
+
+#### Path C — Prompt Export for Manual Generation
+
+Triggered when the user chose "导出 prompt 手动生成" in the Step 5 pre-check, or explicitly requests manual image generation.
+
+```bash
+python3 ${SKILL_DIR}/scripts/dry_run_export.py <project_path>
+```
+
+**Output**: `<project_path>/images/dry-run/` directory with one `.txt` per image.
+
+**Workflow**:
+
+1. Confirm `images/image_prompts.md` exists (generated in §3.1)
+2. Run `dry_run_export.py <project_path>`
+3. Tell the user:
+   - "Prompt 文件已导出到 `project/images/dry-run/` 目录"
+   - "每个 `.txt` 文件包含一个图片的完整 prompt，可以直接复制内容发给 ChatGPT / Midjourney 等工具"
+   - "生成的图片请命名为对应的文件名，放到 `project/images/` 目录下"
+   - List each filename and its purpose
+4. Wait for user to place images
+5. Verify all expected files exist in `project/images/`
+6. Mark status as `Generated` for files that exist, `Needs-Manual` for missing ones
+
+**Fallback from Path A**: If `image_gen.py` fails (bad key, network error), ask: "要不要切换到导出 prompt 手动生成模式？" If yes, run `dry_run_export.py` instead.
 
 #### AI-specific Failure Handling (extends image-base.md §5)
 

--- a/skills/ppt-master/scripts/dry_run_export.py
+++ b/skills/ppt-master/scripts/dry_run_export.py
@@ -6,9 +6,16 @@ Parses image_prompts.md and exports each image prompt to an individual
 .txt file optimized for feeding directly to AI image generators
 (ChatGPT, Midjourney, etc.).
 
+Part of Path C in the image acquisition pipeline.
+See references/image-generator.md §3.2 for the full workflow.
+
 Usage:
     python3 scripts/dry_run_export.py <project_path>
     python3 scripts/dry_run_export.py <project_path> --output-dir custom-dir
+
+Examples:
+    python3 scripts/dry_run_export.py projects/my-ppt
+    python3 scripts/dry_run_export.py projects/my-ppt --output-dir /tmp/prompts
 
 Dependencies:
     None (only uses standard library)

--- a/skills/ppt-master/scripts/dry_run_export.py
+++ b/skills/ppt-master/scripts/dry_run_export.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+PPT Master - Dry-Run Prompt Export
+
+Parses image_prompts.md and exports each image prompt to an individual
+.txt file optimized for feeding directly to AI image generators
+(ChatGPT, Midjourney, etc.).
+
+Usage:
+    python3 scripts/dry_run_export.py <project_path>
+    python3 scripts/dry_run_export.py <project_path> --output-dir custom-dir
+
+Dependencies:
+    None (only uses standard library)
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def _sanitize_filename(filename: str) -> str:
+    """Strip extension, replace spaces/unsafe chars with underscores, collapse, lowercase."""
+    name = Path(filename).stem
+    name = re.sub(r"[^a-zA-Z0-9]+", "_", name)
+    name = name.strip("_").lower()
+    return re.sub(r"_+", "_", name)
+
+
+def _parse_image_blocks(text: str) -> list[dict]:
+    """Parse all image blocks from image_prompts.md content."""
+    blocks = []
+    # Split on ### Image N: headings
+    pattern = re.compile(
+        r"###\s+Image\s+(\d+):\s*(.+?)(?=\n)",
+        re.MULTILINE,
+    )
+    matches = list(pattern.finditer(text))
+
+    for match in matches:
+        image_num = int(match.group(1))
+        filename = match.group(2).strip()
+        # Get the block text (from this heading to the next ### or end)
+        start = match.end()
+        end = matches[matches.index(match) + 1].start() if matches.index(match) + 1 < len(matches) else len(text)
+        block_text = text[start:end]
+
+        result = {
+            "num": image_num,
+            "filename": filename,
+        }
+
+        # Extract Purpose from table row
+        purpose_match = re.search(r"\|\s*Purpose\s*\|\s*(.+?)\s*\|", block_text)
+        result["purpose"] = purpose_match.group(1).strip() if purpose_match else ""
+
+        # Extract Type from table row
+        type_match = re.search(r"\|\s*Type\s*\|\s*(.+?)\s*\|", block_text)
+        result["type"] = type_match.group(1).strip() if type_match else ""
+
+        # Extract Prompt: everything between **Prompt**: and **Alt Text**:
+        prompt_match = re.search(
+            r"\*\*Prompt\*\*\s*:\s*\n(.*?)(?=\n\*\*Alt Text\*\*|\Z)",
+            block_text,
+            re.DOTALL,
+        )
+        result["prompt"] = prompt_match.group(1).strip() if prompt_match else ""
+
+        # Extract Alt Text: the line(s) after **Alt Text**: that start with >
+        alt_match = re.search(
+            r"\*\*Alt Text\*\*\s*:\s*\n>\s*(.*?)(?=\n\n|\n###|\Z)",
+            block_text,
+            re.DOTALL,
+        )
+        result["alt_text"] = alt_match.group(1).strip() if alt_match else ""
+
+        blocks.append(result)
+
+    return blocks
+
+
+def _format_txt(block: dict) -> str:
+    """Format a single image prompt block as a .txt file for AI generators."""
+    purpose = block.get("purpose", "")
+    type_ = block.get("type", "")
+    prompt = block.get("prompt", "")
+    alt_text = block.get("alt_text", "")
+
+    lines = [
+        f"请生成一张图片，用于PPT的{purpose}。",
+        "",
+        f"Purpose: {purpose}",
+        f"Type: {type_}",
+        "",
+        "Prompt:",
+        prompt,
+        "",
+        "Alt Text:",
+        alt_text,
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Export image_prompts.md blocks to individual .txt files for AI image generators.",
+    )
+    parser.add_argument(
+        "project_path",
+        type=Path,
+        help="Path to the PPT project directory (must contain images/image_prompts.md)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Custom output directory (default: <project_path>/images/dry-run/)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    prompts_path = args.project_path / "images" / "image_prompts.md"
+    if not prompts_path.exists():
+        print(f"Error: {prompts_path} not found", file=sys.stderr)
+        return 1
+
+    text = prompts_path.read_text(encoding="utf-8")
+    blocks = _parse_image_blocks(text)
+
+    if not blocks:
+        print("Warning: no parseable image blocks found in image_prompts.md", file=sys.stderr)
+        return 1
+
+    out_dir = args.output_dir if args.output_dir else args.project_path / "images" / "dry-run"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    exported = 0
+    for block in blocks:
+        try:
+            sanitized = _sanitize_filename(block["filename"])
+            padded = f"{block['num']:02d}_{sanitized}.txt"
+            out_file = out_dir / padded
+            out_file.write_text(_format_txt(block), encoding="utf-8")
+            exported += 1
+        except Exception as exc:
+            print(f"Warning: skipping image {block['num']}: {exc}", file=sys.stderr)
+
+    print(f"Exported {exported} prompt file(s) to {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ppt-master/scripts/dry_run_export.py
+++ b/skills/ppt-master/scripts/dry_run_export.py
@@ -95,10 +95,9 @@ def _format_txt(block: dict) -> str:
         "",
         "Prompt:",
         prompt,
-        "",
-        "Alt Text:",
-        alt_text,
     ]
+    if alt_text:
+        lines.extend(["", "Alt Text:", alt_text])
     return "\n".join(lines) + "\n"
 
 
@@ -106,6 +105,7 @@ def build_parser() -> argparse.ArgumentParser:
     """Build the argument parser."""
     parser = argparse.ArgumentParser(
         description="Export image_prompts.md blocks to individual .txt files for AI image generators.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "project_path",


### PR DESCRIPTION
## 概述

为图片获取流程新增 Path C（导出 prompt 手动生成）：当用户没有图片生成 API key 时，AI 询问是网络搜索还是导出 prompt 手动生成。新脚本 `dry_run_export.py` 解析 `image_prompts.md`，将每张图片的 prompt 导出为独立的 `.txt` 文件，可直接复制到 ChatGPT / Midjourney 等工具中生成图片，生成后放回项目目录即可继续流程。

Closes #87

## 实现内容

- **导出脚本** (`scripts/dry_run_export.py`)：解析 `image_prompts.md`，为每张图生成独立的 `.txt` 文件（含 Purpose、Type、Prompt、Alt Text），输出到 `images/dry-run/` 目录
- **SKILL.md 集成**：Step 5 新增图片策略预检，检测到未配置 `IMAGE_BACKEND` 时询问用户选择网络搜索或导出 prompt 手动生成
- **image-generator.md 集成**：路径选择表新增 Path C 行 + Path C 完整工作流章节

## 工作流程

1. 进入 Step 5 时，AI 检测 `IMAGE_BACKEND` 是否配置
2. 未配置 → 询问用户：网络搜索 or 导出 prompt 手动生成
3. 用户选择导出 → AI 生成 `image_prompts.md` → 运行 `dry_run_export.py`
4. AI 告知用户 prompt 文件位置和操作方式
5. 用户复制 `.txt` 中的 prompt 到 ChatGPT 生成图片，下载后放到 `images/` 目录
6. 用户告知 AI → AI 验证图片 → 标记状态 → 继续 Executor 阶段

Path A 失败时也可降级到 Path C：AI 询问"要不要切换到导出 prompt 手动生成模式？"

## 变更文件

| 文件 | 用途 |
|------|------|
| `scripts/dry_run_export.py` | 新增：解析 `image_prompts.md`，导出 per-image `.txt` prompt 文件 |
| `references/image-generator.md` | 路径选择表新增 Path C 行 + Path C 工作流章节 |
| `SKILL.md` | Step 5 新增图片策略预检 block |

## 规范遵循

- **CONTRIBUTING.md**：属于"Scripts — 改进转换/后处理脚本"范畴；零新依赖，仅使用标准库（`re`、`argparse`、`pathlib`）；不涉及 CI、测试框架等禁止项
- **SECURITY.md**：文件名经 `_sanitize_filename()` 处理（仅保留字母数字），无路径穿越风险；路径由 CLI 参数传入，非不可信输入；无新端口或网络暴露
- **CODE_OF_CONDUCT.md**：中文内容专业得体，无违规内容
- **code-style.md**：遵循 shebang、docstring、CLI 入口模式（`build_parser` + `main(argv=None) -> int` + `raise SystemExit(main())`）、`RawDescriptionHelpFormatter`、导入分组、命名规范

## 测试

**自动化测试：**
- `dry_run_export.py` 功能验证：正常导出（2 张图）、缺失 `image_prompts.md` 报错（exit 1）、空文件报错（exit 1）、`--output-dir` 自定义输出目录、无 alt_text 时跳过该段落
- `--help` 输出格式验证（RawDescriptionHelpFormatter）

**人工测试：**
- 完整 PPT 生成流程 × 2 次：预检正确触发 → prompt 导出 → 用户在 ChatGPT 中生成图片 → 放回项目目录 → AI 接管后续流程 → PPT 生成成功
- 验证 AI 不会遗漏已放置的图片

**代码审查：** spec compliance review + code quality review，全部通过

## 对现有流程的影响

- **PPT 生成流程（Step 1-4、Step 6-7）完全未改动**
- Step 5 仅新增一个可选的预检 blockquote，已有 `IMAGE_BACKEND` 配置的用户完全无感
- `image-generator.md` 的 Path A / Path B 内容未修改，仅追加 Path C
- 无新依赖、无新配置项、无破坏性变更