### PR TITLE
fix(svg_to_pptx): drop unresolvable data-icon placeholders instead of aborting export

### DIFF
--- a/skills/ppt-master/scripts/svg_to_pptx/use_expander.py
+++ b/skills/ppt-master/scripts/svg_to_pptx/use_expander.py
@@ -9,9 +9,18 @@ without first running the on-disk finalize step.
 
 Public API:
     expand_use_data_icons(root, icons_dir) -> int
-        Walk the SVG element tree, replace every ``<use data-icon="...">``
-        with its expanded ``<g>`` group of primitive shapes, and return
-        the number of replacements made.
+        Walk the SVG element tree. For every ``<use data-icon="...">``:
+        * if the icon resolves, replace it in-place with the expanded
+          ``<g>`` group of primitive shapes;
+        * if the icon cannot be resolved (file missing / corrupted /
+          empty), **drop the placeholder entirely** with a stdout warning.
+        Returns the number of successfully expanded placeholders.
+
+The drop-on-unresolvable behaviour is deliberate: leaving the ``<use>``
+in place trips ``drawingml_converter._collect_unsupported_visuals`` and
+aborts the *entire deck export* over one hallucinated icon name. A
+silently dropped icon is a much less disruptive failure mode than a dead
+deck, and the warning still surfaces in the run log for diagnosis.
 
 The heavy lifting (icon resolution, color application, scaling) is
 delegated to ``svg_finalize.embed_icons`` so the two pipelines stay
@@ -45,9 +54,9 @@ def _build_replacement_g(
     """Resolve a single ``<use data-icon="...">`` into an expanded ``<g>``.
 
     Returns None when the icon name is missing, unresolved, or the icon
-    file cannot be parsed. Callers should leave the original ``<use>`` in
-    place in that case (matching the on-disk finalize_svg behaviour, which
-    also leaves unresolvable placeholders untouched).
+    file cannot be parsed. The caller (``expand_use_data_icons``) removes
+    the placeholder in that case — leaving it would otherwise trip the
+    DrawingML converter's unsupported-visual guard and abort the export.
     """
     use_str = ET.tostring(use_elem, encoding='unicode')
     attrs = embed_icons_mod.parse_use_element(use_str)
@@ -91,8 +100,13 @@ def expand_use_data_icons(root: ET.Element, icons_dir: Path) -> int:
     builds a new ``<g>`` subtree from the corresponding icon library, and
     swaps it into the parent element at the same position.
 
-    Returns the number of placeholders successfully expanded. Unresolvable
-    placeholders are left in place so callers can decide whether to warn.
+    Unresolvable placeholders (missing icon file / corrupted / empty) are
+    **removed** from the tree with a ``[WARN]`` line printed to stdout, so
+    they don't reach the DrawingML converter's unsupported-visual guard and
+    kill the whole deck. The warning is captured by callers that pipe stdout
+    (the FastAPI pipeline uses ``_silenced_stdout`` → loguru).
+
+    Returns the number of placeholders **successfully expanded**.
     """
     if not icons_dir.exists():
         return 0
@@ -117,11 +131,16 @@ def expand_use_data_icons(root: ET.Element, icons_dir: Path) -> int:
         if parent is None:
             continue
         replacement = _build_replacement_g(use_elem, icons_dir, embed_icons_mod)
-        if replacement is None:
-            continue
         idx = list(parent).index(use_elem)
         parent.remove(use_elem)
-        parent.insert(idx, replacement)
-        expanded += 1
+        if replacement is not None:
+            parent.insert(idx, replacement)
+            expanded += 1
+        else:
+            icon_name = use_elem.get('data-icon', '<unknown>')
+            print(
+                f'  [WARN] use_expander dropped unresolvable '
+                f'<use data-icon="{icon_name}"/> (icon not found in library)'
+            )
 
     return expanded


### PR DESCRIPTION
## Summary

When `<use data-icon="lib/name"/>` references an icon that doesn't exist in the configured icon library (missing file, corrupted, or empty), `use_expander.expand_use_data_icons` previously **left the placeholder in the tree**. That single surviving `<use>` then trips `drawingml_converter._collect_unsupported_visuals()` and aborts the entire deck export with:

```
unsupported visual SVG element(s): /svg[N]/g[N]/use
```

This PR changes the behaviour: an unresolvable placeholder is **removed** from the tree with a `[WARN]` line printed to stdout, matching the same warn-and-continue contract `finalize_svg.embed_icons` already uses on the on-disk pipeline.

## Motivation

This failure is easy to trigger when ppt-master is driven by LLM-generated SVG (Strategist/Executor in agentic pipelines, or any author copy-pasting from a wider icon vocabulary). LLMs frequently emit Material/Heroicons-style names that don't exist in Tabler:

| Hallucinated name | Actual Tabler name |
|---|---|
| `check-circle` | `circle-check` |
| `bar-chart` | `chart-bar` |
| `pie-chart` | `chart-pie` |
| `molecule` | `atom` |
| `lightbulb` | `bulb` |

One such name in one slide currently kills the whole N-slide export. The user sees nothing — no partial deck, no per-slide warning surface, just a single hard error. Re-running with prompt guidance helps statistically but cannot drive the error rate to zero against a 5000+ icon library that doesn't fit in any prompt.

## The fix

In `expand_use_data_icons`:

* Always remove the original `<use>` from its parent.
* If resolution **succeeded**, re-insert the expanded `<g>` at the same index (unchanged behaviour for happy path).
* If resolution **failed**, print `[WARN] use_expander dropped unresolvable <use data-icon="..."/> (icon not found in library)`. The warning string mirrors the `[WARN] Icon not found:` lines `finalize_svg.embed_icons` already emits, so log scrapers don't need new patterns.
* The return value still counts **successfully expanded** placeholders, so existing callers (the verbose log in `drawingml_converter.convert_svg_to_slide_shapes` is the only one) keep working.

Docstrings updated accordingly.

## Trade-off acknowledged

A silently dropped icon is a visible degradation on the affected slide (a blank where the icon should have been). That is intentionally less disruptive than the current behaviour where the entire deck fails to export. After the fix:

* The user gets every slide they paid LLM tokens for.
* The warning log records exactly which icon name failed, on which slide, so it's actionable for the author or the calling agent.
* Re-running with the corrected icon name produces a clean deck.

Before the fix:

* The user gets zero slides.
* The error message names the SVG path (`/svg[5]/g[3]/use`) but not the icon name, requiring manual SVG inspection to debug.
* Re-running is the only option, and there's no signal which icon to fix.

## Scope

* Single file: `skills/ppt-master/scripts/svg_to_pptx/use_expander.py`
* No new dependencies, no API change, no behaviour change on the happy path.
* Reused the existing stdout `[WARN]` channel rather than adding a return type or logging dependency.
* On-disk `finalize_svg.embed_icons` path is untouched — that pipeline already does the right thing.

## Test plan

- [x] Synthetic SVG with mixed valid + invalid `data-icon` references: valid one expands to `<g>`, invalid one removed from tree, `[WARN]` line printed naming the dropped icon.
- [x] End-to-end via `drawingml_converter.convert_svg_to_slide_shapes`: slide XML produced successfully instead of `SvgNativeConversionError`.
- [x] Existing tests still pass (no regressions on the happy-path expansion).