### PR TITLE
fix(svg-editor): backfill SVG dimensions from viewBox to fix blank live preview

### DIFF
--- a/skills/ppt-master/scripts/svg_editor/static/app.js
+++ b/skills/ppt-master/scripts/svg_editor/static/app.js
@@ -354,6 +354,18 @@
                 // Empty-canvas guard: surface a clear error if the SVG parsed
                 // to nothing renderable (issue #115's silent-blank scenario).
                 var rootSvg = svgContent.querySelector("svg");
+                // DOMParser → XMLSerializer round-trip strips implicit dimensions,
+                // collapsing the SVG to 0×0 in the browser. Backfill from viewBox.
+                if (rootSvg && !rootSvg.hasAttribute("width")) {
+                    var vb = rootSvg.getAttribute("viewBox");
+                    if (vb) {
+                        var parts = vb.trim().split(/[\s,]+/);
+                        if (parts.length === 4) {
+                            rootSvg.setAttribute("width", parts[2]);
+                            rootSvg.setAttribute("height", parts[3]);
+                        }
+                    }
+                }
                 var hasContent = false;
                 if (rootSvg) {
                     var children = rootSvg.querySelectorAll("*");


### PR DESCRIPTION
## Fix #115 — Live preview shows blank/black SVG

### Root Cause
`sanitizeSvg()` in `app.js` uses `DOMParser` → `XMLSerializer` round-trip to clean incoming SVG. This round-trip strips `width`/`height` attributes when they are implicit (derived from `viewBox`). The browser then renders the SVG at 0x0, causing a blank preview.

### Fix
Backfill `width` and `height` from `viewBox` after parsing, only when the attributes are missing.

### Testing
- Verified with 2-page SVG deck (latex_formula_demo project) — live preview renders correctly with and without explicit width/height on source SVGs.
- No changes to shared SVG generation standards; fix is entirely frontend-side.

Closes #115