### PR TITLE
feat(latex): add LaTeX formula rendering via CodeCogs API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,10 @@ python3 skills/ppt-master/scripts/total_md_split.py <project_path>
 python3 skills/ppt-master/scripts/finalize_svg.py <project_path>
 python3 skills/ppt-master/scripts/svg_to_pptx.py <project_path>
 # Add --merge-paragraphs when the user wants paragraph-level editable text frames instead of one-per-line (default off, see SKILL.md Step 7.3).
+
+# Formula rendering (only when spec_lock.md contains LaTeX)
+python3 skills/ppt-master/scripts/latex_render.py <project_path>
+python3 skills/ppt-master/scripts/latex_render.py <project_path> --dry-run
 ```
 
 ## Core Directories

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ python3 skills/ppt-master/scripts/svg_to_pptx.py <project_path>
 # Formula rendering (only when spec_lock.md contains LaTeX)
 python3 skills/ppt-master/scripts/latex_render.py <project_path>
 python3 skills/ppt-master/scripts/latex_render.py <project_path> --dry-run
+python3 skills/ppt-master/scripts/latex_render.py <project_path> --dpi 400
 ```
 
 ## Core Directories

--- a/skills/ppt-master/SKILL.md
+++ b/skills/ppt-master/SKILL.md
@@ -291,6 +291,24 @@ python3 ${SKILL_DIR}/scripts/analyze_images.py <project_path>/images
 
 ---
 
+### Step 4.5: Formula Rendering (Conditional)
+
+🚧 **GATE**: Step 4 complete; `spec_lock.md` generated.
+
+> **Trigger**: `spec_lock.md` contains `$...$` or `$$...$$` LaTeX formulas. If no formulas are detected, skip to Step 5.
+
+```bash
+python3 ${SKILL_DIR}/scripts/latex_render.py <project_path>
+```
+
+This scans `spec_lock.md`, renders each LaTeX formula to a transparent PNG image in `images/latex/`, and replaces the formula text with `![](images/latex/F01.png)` references. Executor treats these as normal images — no Executor changes needed.
+
+**Dry-run available**: `python3 ${SKILL_DIR}/scripts/latex_render.py <project_path> --dry-run` shows what would be rendered without modifying files.
+
+**✅ Checkpoint — Formulas rendered (or no formulas found). Auto-proceed to Step 5.**
+
+---
+
 ### Step 5: Image Acquisition Phase (Conditional)
 
 🚧 **GATE**: Step 4 complete; Design Specification & Content Outline generated and user confirmed.

--- a/skills/ppt-master/SKILL.md
+++ b/skills/ppt-master/SKILL.md
@@ -301,9 +301,11 @@ python3 ${SKILL_DIR}/scripts/analyze_images.py <project_path>/images
 python3 ${SKILL_DIR}/scripts/latex_render.py <project_path>
 ```
 
-This scans `spec_lock.md`, renders each LaTeX formula to a transparent PNG image in `images/latex/`, and replaces the formula text with `![](images/latex/F01.png)` references. Executor treats these as normal images — no Executor changes needed.
+This scans `spec_lock.md`, renders each LaTeX formula to a transparent PNG image in `images/latex/` via the CodeCogs online LaTeX API, and replaces the formula text with `![](images/latex/F01.png)` references. A sidecar `images/latex/manifest.json` records each formula's pixel dimensions, type (inline/block), and a **uniform scale factor**. When placing formula images in SVG, the executor must apply `manifest.uniform_scale` to ALL formula images so that letter sizes remain consistent across formulas — do NOT normalize heights individually.
 
 **Dry-run available**: `python3 ${SKILL_DIR}/scripts/latex_render.py <project_path> --dry-run` shows what would be rendered without modifying files.
+
+**DPI control**: `python3 ${SKILL_DIR}/scripts/latex_render.py <project_path> --dpi 400` — higher DPI produces larger source images (default 300).
 
 **✅ Checkpoint — Formulas rendered (or no formulas found). Auto-proceed to Step 5.**
 

--- a/skills/ppt-master/references/executor-base.md
+++ b/skills/ppt-master/references/executor-base.md
@@ -98,7 +98,7 @@ Before the first SVG page, output a confirmation listing: canvas dimensions, bod
 - Font family from `typography`: use role override (`title_family` / `body_family` / `emphasis_family` / `code_family`) if declared, else fall back to `font_family`
 - Font sizes follow a **ramp anchored on `typography.body`**, not a closed menu. Use the declared slots when they fit. Intermediate sizes (e.g., 40px hero number, 13px annotation) are allowed if the ratio to `body` falls within the role's band (see `design_spec.md §IV ramp table`). Sizes outside every band require extending the lock first.
 - Images MUST reference files listed under `images`; no invented filenames
-- **Formula images** (`images/latex/F*.png`) are pre-rendered by `latex_render.py` (Step 4.5) via the CodeCogs API. Place them as `<image>` elements using the `uniform_scale` from `images/latex/manifest.json` — do NOT render formula text with `code_family` or any font stack
+- **Formula images** (`images/latex/F*.png`) are pre-rendered by `latex_render.py` (Step 4.5) via the CodeCogs API. Place them as `<image>` elements using the `uniform_scale` from `images/latex/manifest.json` — do NOT render formula text with `code_family` or any font stack. Inline formulas align with surrounding text baseline; block formulas center in the content area.
 
 If a page needs a value not in `spec_lock.md`, surface it — do not silently invent one.
 
@@ -337,7 +337,7 @@ Use `attribution_text` from the manifest entry as the **starting point**, then c
 
 ## 7. Font Usage
 
-Source of truth: `spec_lock.md typography`. Use `font_family` as default; override per role with `title_family` / `body_family` / `emphasis_family` / `code_family` if declared. **LaTeX formulas bypass typography entirely** — they are pre-rendered PNG images placed as `<image>` elements (see Step 4.5).
+Source of truth: `spec_lock.md typography`. Use `font_family` as default; override per role with `title_family` / `body_family` / `emphasis_family` / `code_family` if declared. **LaTeX formulas are not a font-stack role** — they are pre-rendered PNG images (Step 4.5); size them via `manifest.json` `uniform_scale` and align with surrounding text.
 
 If `spec_lock.md` is absent, consult [`strategist.md`](strategist.md) §g — do not invent a stack.
 

--- a/skills/ppt-master/references/executor-base.md
+++ b/skills/ppt-master/references/executor-base.md
@@ -98,6 +98,7 @@ Before the first SVG page, output a confirmation listing: canvas dimensions, bod
 - Font family from `typography`: use role override (`title_family` / `body_family` / `emphasis_family` / `code_family`) if declared, else fall back to `font_family`
 - Font sizes follow a **ramp anchored on `typography.body`**, not a closed menu. Use the declared slots when they fit. Intermediate sizes (e.g., 40px hero number, 13px annotation) are allowed if the ratio to `body` falls within the role's band (see `design_spec.md §IV ramp table`). Sizes outside every band require extending the lock first.
 - Images MUST reference files listed under `images`; no invented filenames
+- **Formula images** (`images/latex/F*.png`) are pre-rendered by `latex_render.py` (Step 4.5) via the CodeCogs API. Place them as `<image>` elements using the `uniform_scale` from `images/latex/manifest.json` — do NOT render formula text with `code_family` or any font stack
 
 If a page needs a value not in `spec_lock.md`, surface it — do not silently invent one.
 
@@ -336,7 +337,7 @@ Use `attribution_text` from the manifest entry as the **starting point**, then c
 
 ## 7. Font Usage
 
-Source of truth: `spec_lock.md typography`. Use `font_family` as default; override per role with `title_family` / `body_family` / `emphasis_family` / `code_family` if declared.
+Source of truth: `spec_lock.md typography`. Use `font_family` as default; override per role with `title_family` / `body_family` / `emphasis_family` / `code_family` if declared. **LaTeX formulas bypass typography entirely** — they are pre-rendered PNG images placed as `<image>` elements (see Step 4.5).
 
 If `spec_lock.md` is absent, consult [`strategist.md`](strategist.md) §g — do not invent a stack.
 

--- a/skills/ppt-master/references/executor-base.md
+++ b/skills/ppt-master/references/executor-base.md
@@ -98,7 +98,7 @@ Before the first SVG page, output a confirmation listing: canvas dimensions, bod
 - Font family from `typography`: use role override (`title_family` / `body_family` / `emphasis_family` / `code_family`) if declared, else fall back to `font_family`
 - Font sizes follow a **ramp anchored on `typography.body`**, not a closed menu. Use the declared slots when they fit. Intermediate sizes (e.g., 40px hero number, 13px annotation) are allowed if the ratio to `body` falls within the role's band (see `design_spec.md §IV ramp table`). Sizes outside every band require extending the lock first.
 - Images MUST reference files listed under `images`; no invented filenames
-- **Formula images** (`images/latex/F*.png`) are pre-rendered by `latex_render.py` (Step 4.5) via the CodeCogs API. Place them as `<image>` elements using the `uniform_scale` from `images/latex/manifest.json` — do NOT render formula text with `code_family` or any font stack. Inline formulas align with surrounding text baseline; block formulas center in the content area.
+- **Formula images** (`images/latex/F*.png`) are pre-rendered by `latex_render.py` (Step 4.5) via the CodeCogs API. Place them as `<image>` elements using the `uniform_scale` from `images/latex/manifest.json` — do NOT render formula text with `code_family` or any font stack.
 
 If a page needs a value not in `spec_lock.md`, surface it — do not silently invent one.
 

--- a/skills/ppt-master/references/strategist.md
+++ b/skills/ppt-master/references/strategist.md
@@ -642,7 +642,7 @@ Templates are starting points. The Strategist may adjust based on content and au
 | I. Project Information | Project name, canvas format, page count, style, audience, scenario, date |
 | II. Canvas Specification | Format, dimensions, viewBox, margins, content area |
 | III. Visual Theme | Style description, light/dark theme, tone, color scheme (with HEX table), gradient scheme |
-| IV. Typography System | Font plan (per-role families — title / body / emphasis / code), font size hierarchy. **Note**: LaTeX formulas are NOT a typography role — they are pre-rendered to PNG images via CodeCogs API (Step 4.5) and placed as `<image>` elements, bypassing font stacks entirely. |
+| IV. Typography System | Font plan (per-role families — title / body / emphasis / code), font size hierarchy. **Note**: LaTeX formulas are pre-rendered to PNG images via CodeCogs API (Step 4.5) and placed as `<image>` elements — they are not rendered with any font stack, but their display size must align with surrounding typography via `manifest.json` `uniform_scale`. |
 | V. Layout Principles | Page structure (header/content/footer zones), layout pattern library (combine/break as content demands), spacing spec |
 | VI. Icon Usage Spec | Source description, placeholder syntax, recommended icon list |
 | VII. Visualization Reference List | Visualization type, reference template path, used-in pages, purpose |

--- a/skills/ppt-master/references/strategist.md
+++ b/skills/ppt-master/references/strategist.md
@@ -26,7 +26,7 @@ As a top-tier AI presentation strategist, receive source documents, perform cont
 
 > **Execution discipline**: This is the last BLOCKING checkpoint in the pipeline. After confirmation, complete the Design Spec and proceed to image generation / SVG / post-processing without further pauses.
 
-> **LaTeX formula handling**: When the source content contains mathematical formulas or equations, write them in `spec_lock.md` using standard LaTeX syntax: `$...$` for inline formulas and `$$...$$` for display (block) formulas. Even if the source text does not use LaTeX notation, identify mathematical expressions and convert them to proper LaTeX. When no formulas are present, this rule does not apply.
+> **LaTeX formula handling**: When the source content contains mathematical formulas or equations, write them in `spec_lock.md` using standard LaTeX syntax: `$...$` for inline formulas and `$$...$$` for display (block) formulas. Even if the source text does not use LaTeX notation, identify mathematical expressions and convert them to proper LaTeX. When no formulas are present, this rule does not apply. Formulas are NOT rendered by the Executor using `code_family` — they are pre-rendered to transparent PNG images by `scripts/latex_render.py` (Step 4.5) via the CodeCogs online LaTeX API, then placed in SVG as normal `<image>` elements.
 
 ### a. Canvas Format Confirmation
 
@@ -642,7 +642,7 @@ Templates are starting points. The Strategist may adjust based on content and au
 | I. Project Information | Project name, canvas format, page count, style, audience, scenario, date |
 | II. Canvas Specification | Format, dimensions, viewBox, margins, content area |
 | III. Visual Theme | Style description, light/dark theme, tone, color scheme (with HEX table), gradient scheme |
-| IV. Typography System | Font plan (per-role families — title / body / emphasis / code), font size hierarchy |
+| IV. Typography System | Font plan (per-role families — title / body / emphasis / code), font size hierarchy. **Note**: LaTeX formulas are NOT a typography role — they are pre-rendered to PNG images via CodeCogs API (Step 4.5) and placed as `<image>` elements, bypassing font stacks entirely. |
 | V. Layout Principles | Page structure (header/content/footer zones), layout pattern library (combine/break as content demands), spacing spec |
 | VI. Icon Usage Spec | Source description, placeholder syntax, recommended icon list |
 | VII. Visualization Reference List | Visualization type, reference template path, used-in pages, purpose |

--- a/skills/ppt-master/references/strategist.md
+++ b/skills/ppt-master/references/strategist.md
@@ -26,6 +26,8 @@ As a top-tier AI presentation strategist, receive source documents, perform cont
 
 > **Execution discipline**: This is the last BLOCKING checkpoint in the pipeline. After confirmation, complete the Design Spec and proceed to image generation / SVG / post-processing without further pauses.
 
+> **LaTeX formula handling**: When the source content contains mathematical formulas or equations, write them in `spec_lock.md` using standard LaTeX syntax: `$...$` for inline formulas and `$$...$$` for display (block) formulas. Even if the source text does not use LaTeX notation, identify mathematical expressions and convert them to proper LaTeX. When no formulas are present, this rule does not apply.
+
 ### a. Canvas Format Confirmation
 
 Recommend format based on scenario (see [`canvas-formats.md`](canvas-formats.md)).

--- a/skills/ppt-master/scripts/latex_render.py
+++ b/skills/ppt-master/scripts/latex_render.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""PPT Master - LaTeX Formula Renderer
+
+Render LaTeX formulas in spec_lock.md to transparent PNG images.
+
+Dependencies: matplotlib (pip install matplotlib)
+
+Usage:
+    python3 scripts/latex_render.py <project_path>
+    python3 scripts/latex_render.py <project_path> --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Regex patterns: $$...$$ (block) matched BEFORE $...$ (inline)
+# ---------------------------------------------------------------------------
+_RE_BLOCK = re.compile(r"\$\$([^$]+?)\$\$", re.DOTALL)
+_RE_INLINE = re.compile(r"\$([^$\n]+?)\$")
+
+
+def extract_formulas(text: str) -> list[tuple[str, str, bool]]:
+    """Extract all formulas from text.
+
+    Returns list of (full_match, latex_content, is_block).
+    Block formulas ($$...$$) are extracted first, then inline ($...$).
+    """
+    results: list[tuple[str, str, bool]] = []
+    # Track spans already claimed by block matches
+    claimed: list[tuple[int, int]] = []
+
+    for m in _RE_BLOCK.finditer(text):
+        results.append((m.group(0), m.group(1).strip(), True))
+        claimed.append((m.start(), m.end()))
+
+    for m in _RE_INLINE.finditer(text):
+        # Skip if this position overlaps a claimed block span
+        if any(s <= m.start() < e for s, e in claimed):
+            continue
+        results.append((m.group(0), m.group(1).strip(), False))
+
+    return results
+
+
+def render_formula(latex: str, output_path: Path, dpi: int = 300) -> bool:
+    """Render a single LaTeX formula to a transparent PNG.
+
+    Returns True on success, False on failure (prints warning).
+    """
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots()
+        ax.axis("off")
+        ax.text(0, 0.5, f"${latex}$", fontsize=20, ha="left", va="center",
+                transform=ax.transAxes)
+        fig.savefig(
+            str(output_path),
+            dpi=dpi,
+            transparent=True,
+            bbox_inches="tight",
+            pad_inches=0.05,
+        )
+        plt.close(fig)
+        return True
+    except Exception as exc:
+        print(f"  [WARN] Failed to render '{latex}': {exc}", file=sys.stderr)
+        return False
+
+
+def process_spec_lock(project_path: Path, dry_run: bool = False) -> int:
+    """Main entry: scan spec_lock.md, render, replace.
+
+    Returns number of formulas rendered.
+    """
+    spec_lock = project_path / "spec_lock.md"
+    if not spec_lock.is_file():
+        print("spec_lock.md not found; nothing to do.")
+        return 0
+
+    text = spec_lock.read_text(encoding="utf-8")
+    formulas = extract_formulas(text)
+
+    if not formulas:
+        print("No LaTeX formulas found in spec_lock.md.")
+        return 0
+
+    # Deduplicate: same latex → same file
+    seen: dict[str, str] = {}  # latex → file reference like "images/latex/F01.png"
+    counter = 1
+    replacements: list[tuple[str, str, str]] = []  # (full_match, file_ref, latex)
+
+    for full_match, latex, is_block in formulas:
+        if latex in seen:
+            replacements.append((full_match, seen[latex], latex))
+            continue
+        file_ref = f"images/latex/F{counter:02d}.png"
+        seen[latex] = file_ref
+        replacements.append((full_match, file_ref, latex))
+        counter += 1
+
+    print(f"Found {len(replacements)} formula(s) ({len(seen)} unique).\n")
+
+    if dry_run:
+        for full_match, file_ref, latex in replacements:
+            print(f"  {file_ref}: {latex}")
+        return 0
+
+    # Ensure output directory exists
+    latex_dir = project_path / "images" / "latex"
+    latex_dir.mkdir(parents=True, exist_ok=True)
+
+    # Render unique formulas
+    rendered = 0
+    for latex, file_ref in seen.items():
+        out_path = project_path / file_ref
+        if out_path.exists():
+            print(f"  [SKIP] {file_ref} (already exists)")
+            continue
+        if render_formula(latex, out_path):
+            print(f"  [OK]   {file_ref}: {latex}")
+            rendered += 1
+
+    # Build set of formulas with valid PNGs (rendered or pre-existing)
+    rendered_ok: set[str] = set()
+    for latex, file_ref in seen.items():
+        if (project_path / file_ref).exists():
+            rendered_ok.add(latex)
+
+    # Replace only formulas whose PNG exists on disk
+    new_text = text
+    replaced = 0
+    for full_match, file_ref, latex in replacements:
+        if latex in rendered_ok:
+            new_text = new_text.replace(full_match, f"![]({file_ref})", 1)
+            replaced += 1
+        else:
+            print(f"  [SKIP] {file_ref}: render failed, keeping original text", file=sys.stderr)
+
+    if replaced > 0:
+        spec_lock.write_text(new_text, encoding="utf-8")
+    print(f"\nRendered {rendered} formula(s), replaced {replaced} in spec_lock.md.")
+    return rendered
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Render LaTeX formulas in spec_lock.md to transparent PNG images."
+    )
+    parser.add_argument(
+        "project_path",
+        type=Path,
+        help="Path to the project directory (must contain spec_lock.md).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be rendered without actually rendering or modifying files.",
+    )
+    args = parser.parse_args(argv)
+
+    project = args.project_path.resolve()
+    if not project.is_dir():
+        print(f"Error: {project} is not a directory.", file=sys.stderr)
+        return 1
+
+    return 0 if process_spec_lock(project, dry_run=args.dry_run) >= 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ppt-master/scripts/latex_render.py
+++ b/skills/ppt-master/scripts/latex_render.py
@@ -3,11 +3,14 @@
 
 Render LaTeX formulas in spec_lock.md to transparent PNG images.
 
-Dependencies: matplotlib (pip install matplotlib)
+Backends (tried in order unless --backend is specified):
+  1. codecogs  – CodeCogs online LaTeX API (pdflatex quality, needs internet)
+  2. matplotlib – matplotlib.mathtext (offline, lower quality)
 
 Usage:
-    python3 scripts/latex_render.py <project_path>
-    python3 scripts/latex_render.py <project_path> --dry-run
+    python scripts/latex_render.py <project_path>
+    python scripts/latex_render.py <project_path> --dry-run
+    python scripts/latex_render.py <project_path> --backend matplotlib
 """
 
 from __future__ import annotations
@@ -15,6 +18,8 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+import urllib.parse
+import urllib.request
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -22,6 +27,8 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 _RE_BLOCK = re.compile(r"\$\$([^$]+?)\$\$", re.DOTALL)
 _RE_INLINE = re.compile(r"\$([^$\n]+?)\$")
+
+_BACKEND_ORDER = ("codecogs", "matplotlib")
 
 
 def extract_formulas(text: str) -> list[tuple[str, str, bool]]:
@@ -31,7 +38,6 @@ def extract_formulas(text: str) -> list[tuple[str, str, bool]]:
     Block formulas ($$...$$) are extracted first, then inline ($...$).
     """
     results: list[tuple[str, str, bool]] = []
-    # Track spans already claimed by block matches
     claimed: list[tuple[int, int]] = []
 
     for m in _RE_BLOCK.finditer(text):
@@ -39,7 +45,6 @@ def extract_formulas(text: str) -> list[tuple[str, str, bool]]:
         claimed.append((m.start(), m.end()))
 
     for m in _RE_INLINE.finditer(text):
-        # Skip if this position overlaps a claimed block span
         if any(s <= m.start() < e for s, e in claimed):
             continue
         results.append((m.group(0), m.group(1).strip(), False))
@@ -47,11 +52,24 @@ def extract_formulas(text: str) -> list[tuple[str, str, bool]]:
     return results
 
 
-def render_formula(latex: str, output_path: Path, dpi: int = 300) -> bool:
-    """Render a single LaTeX formula to a transparent PNG.
+def _render_codecogs(latex: str, output_path: Path, dpi: int = 300) -> bool:
+    """Render via CodeCogs online API. Returns True on success."""
+    payload = rf"\dpi{{{dpi}}} {latex}"
+    url = "https://latex.codecogs.com/png.latex?" + urllib.parse.quote(payload)
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "PPT-Master/1.0"})
+        data = urllib.request.urlopen(req, timeout=15).read()
+        if len(data) < 100:
+            return False
+        output_path.write_bytes(data)
+        return True
+    except Exception as exc:
+        print(f"  [WARN] CodeCogs failed for '{latex}': {exc}", file=sys.stderr)
+        return False
 
-    Returns True on success, False on failure (prints warning).
-    """
+
+def _render_matplotlib(latex: str, output_path: Path, dpi: int = 300) -> bool:
+    """Render via matplotlib.mathtext. Returns True on success."""
     try:
         import matplotlib
         matplotlib.use("Agg")
@@ -71,11 +89,21 @@ def render_formula(latex: str, output_path: Path, dpi: int = 300) -> bool:
         plt.close(fig)
         return True
     except Exception as exc:
-        print(f"  [WARN] Failed to render '{latex}': {exc}", file=sys.stderr)
+        print(f"  [WARN] matplotlib failed for '{latex}': {exc}", file=sys.stderr)
         return False
 
 
-def process_spec_lock(project_path: Path, dry_run: bool = False) -> int:
+_RENDERERS = {
+    "codecogs": _render_codecogs,
+    "matplotlib": _render_matplotlib,
+}
+
+
+def process_spec_lock(
+    project_path: Path,
+    dry_run: bool = False,
+    backend: str = "auto",
+) -> int:
     """Main entry: scan spec_lock.md, render, replace.
 
     Returns number of formulas rendered.
@@ -93,9 +121,9 @@ def process_spec_lock(project_path: Path, dry_run: bool = False) -> int:
         return 0
 
     # Deduplicate: same latex → same file
-    seen: dict[str, str] = {}  # latex → file reference like "images/latex/F01.png"
+    seen: dict[str, str] = {}
     counter = 1
-    replacements: list[tuple[str, str, str]] = []  # (full_match, file_ref, latex)
+    replacements: list[tuple[str, str, str]] = []
 
     for full_match, latex, is_block in formulas:
         if latex in seen:
@@ -113,6 +141,12 @@ def process_spec_lock(project_path: Path, dry_run: bool = False) -> int:
             print(f"  {file_ref}: {latex}")
         return 0
 
+    # Determine backend order
+    if backend == "auto":
+        backends = _BACKEND_ORDER
+    else:
+        backends = (backend,)
+
     # Ensure output directory exists
     latex_dir = project_path / "images" / "latex"
     latex_dir.mkdir(parents=True, exist_ok=True)
@@ -124,11 +158,19 @@ def process_spec_lock(project_path: Path, dry_run: bool = False) -> int:
         if out_path.exists():
             print(f"  [SKIP] {file_ref} (already exists)")
             continue
-        if render_formula(latex, out_path):
-            print(f"  [OK]   {file_ref}: {latex}")
-            rendered += 1
+        ok = False
+        for be in backends:
+            renderer = _RENDERERS.get(be)
+            if renderer and renderer(latex, out_path):
+                print(f"  [OK]   {file_ref} ({be}): {latex}")
+                rendered += 1
+                ok = True
+                break
+        if not ok:
+            print(f"  [FAIL] {file_ref}: all backends failed for '{latex}'",
+                  file=sys.stderr)
 
-    # Build set of formulas with valid PNGs (rendered or pre-existing)
+    # Build set of formulas with valid PNGs
     rendered_ok: set[str] = set()
     for latex, file_ref in seen.items():
         if (project_path / file_ref).exists():
@@ -142,7 +184,8 @@ def process_spec_lock(project_path: Path, dry_run: bool = False) -> int:
             new_text = new_text.replace(full_match, f"![]({file_ref})", 1)
             replaced += 1
         else:
-            print(f"  [SKIP] {file_ref}: render failed, keeping original text", file=sys.stderr)
+            print(f"  [KEEP] {file_ref}: render failed, keeping original LaTeX",
+                  file=sys.stderr)
 
     if replaced > 0:
         spec_lock.write_text(new_text, encoding="utf-8")
@@ -162,7 +205,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Show what would be rendered without actually rendering or modifying files.",
+        help="Show what would be rendered without modifying files.",
+    )
+    parser.add_argument(
+        "--backend",
+        choices=("auto", "codecogs", "matplotlib"),
+        default="auto",
+        help="Rendering backend. 'auto' tries codecogs then matplotlib (default).",
     )
     args = parser.parse_args(argv)
 
@@ -171,7 +220,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: {project} is not a directory.", file=sys.stderr)
         return 1
 
-    return 0 if process_spec_lock(project, dry_run=args.dry_run) >= 0 else 1
+    return 0 if process_spec_lock(project, dry_run=args.dry_run, backend=args.backend) >= 0 else 1
 
 
 if __name__ == "__main__":

--- a/skills/ppt-master/scripts/latex_render.py
+++ b/skills/ppt-master/scripts/latex_render.py
@@ -1,21 +1,23 @@
 #!/usr/bin/env python3
 """PPT Master - LaTeX Formula Renderer
 
-Render LaTeX formulas in spec_lock.md to transparent PNG images.
+Render LaTeX formulas in spec_lock.md to transparent PNG images
+via the CodeCogs online LaTeX API (pdflatex quality).
 
-Backends (tried in order unless --backend is specified):
-  1. codecogs  – CodeCogs online LaTeX API (pdflatex quality, needs internet)
-  2. matplotlib – matplotlib.mathtext (offline, lower quality)
+A sidecar manifest (images/latex/manifest.json) records each formula's
+pixel dimensions and type (inline/block) so the SVG executor can place
+images at the correct scale.
 
 Usage:
     python scripts/latex_render.py <project_path>
     python scripts/latex_render.py <project_path> --dry-run
-    python scripts/latex_render.py <project_path> --backend matplotlib
+    python scripts/latex_render.py <project_path> --dpi 400
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 import urllib.parse
@@ -28,7 +30,7 @@ from pathlib import Path
 _RE_BLOCK = re.compile(r"\$\$([^$]+?)\$\$", re.DOTALL)
 _RE_INLINE = re.compile(r"\$([^$\n]+?)\$")
 
-_BACKEND_ORDER = ("codecogs", "matplotlib")
+_MANIFEST_NAME = "manifest.json"
 
 
 def extract_formulas(text: str) -> list[tuple[str, str, bool]]:
@@ -52,57 +54,39 @@ def extract_formulas(text: str) -> list[tuple[str, str, bool]]:
     return results
 
 
-def _render_codecogs(latex: str, output_path: Path, dpi: int = 300) -> bool:
-    """Render via CodeCogs online API. Returns True on success."""
+def render_formula(latex: str, output_path: Path, dpi: int = 300) -> bool:
+    """Render a single LaTeX formula to a transparent PNG via CodeCogs.
+
+    Returns True on success, False on failure.
+    """
     payload = rf"\dpi{{{dpi}}} {latex}"
     url = "https://latex.codecogs.com/png.latex?" + urllib.parse.quote(payload)
     try:
         req = urllib.request.Request(url, headers={"User-Agent": "PPT-Master/1.0"})
         data = urllib.request.urlopen(req, timeout=15).read()
-        if len(data) < 100:
+        if len(data) < 50:
             return False
         output_path.write_bytes(data)
         return True
     except Exception as exc:
-        print(f"  [WARN] CodeCogs failed for '{latex}': {exc}", file=sys.stderr)
+        print(f"  [WARN] CodeCogs API failed for '{latex}': {exc}", file=sys.stderr)
         return False
 
 
-def _render_matplotlib(latex: str, output_path: Path, dpi: int = 300) -> bool:
-    """Render via matplotlib.mathtext. Returns True on success."""
+def _image_dimensions(path: Path) -> tuple[int, int] | None:
+    """Read PNG dimensions without full decode."""
     try:
-        import matplotlib
-        matplotlib.use("Agg")
-        import matplotlib.pyplot as plt
-
-        fig, ax = plt.subplots()
-        ax.axis("off")
-        ax.text(0, 0.5, f"${latex}$", fontsize=20, ha="left", va="center",
-                transform=ax.transAxes)
-        fig.savefig(
-            str(output_path),
-            dpi=dpi,
-            transparent=True,
-            bbox_inches="tight",
-            pad_inches=0.05,
-        )
-        plt.close(fig)
-        return True
-    except Exception as exc:
-        print(f"  [WARN] matplotlib failed for '{latex}': {exc}", file=sys.stderr)
-        return False
-
-
-_RENDERERS = {
-    "codecogs": _render_codecogs,
-    "matplotlib": _render_matplotlib,
-}
+        from PIL import Image
+        with Image.open(path) as img:
+            return img.size
+    except Exception:
+        return None
 
 
 def process_spec_lock(
     project_path: Path,
     dry_run: bool = False,
-    backend: str = "auto",
+    dpi: int = 300,
 ) -> int:
     """Main entry: scan spec_lock.md, render, replace.
 
@@ -123,29 +107,24 @@ def process_spec_lock(
     # Deduplicate: same latex → same file
     seen: dict[str, str] = {}
     counter = 1
-    replacements: list[tuple[str, str, str]] = []
+    replacements: list[tuple[str, str, str, bool]] = []  # + is_block
 
     for full_match, latex, is_block in formulas:
         if latex in seen:
-            replacements.append((full_match, seen[latex], latex))
+            replacements.append((full_match, seen[latex], latex, is_block))
             continue
         file_ref = f"images/latex/F{counter:02d}.png"
         seen[latex] = file_ref
-        replacements.append((full_match, file_ref, latex))
+        replacements.append((full_match, file_ref, latex, is_block))
         counter += 1
 
     print(f"Found {len(replacements)} formula(s) ({len(seen)} unique).\n")
 
     if dry_run:
-        for full_match, file_ref, latex in replacements:
-            print(f"  {file_ref}: {latex}")
+        for full_match, file_ref, latex, is_block in replacements:
+            tag = "block" if is_block else "inline"
+            print(f"  {file_ref} [{tag}]: {latex}")
         return 0
-
-    # Determine backend order
-    if backend == "auto":
-        backends = _BACKEND_ORDER
-    else:
-        backends = (backend,)
 
     # Ensure output directory exists
     latex_dir = project_path / "images" / "latex"
@@ -158,17 +137,48 @@ def process_spec_lock(
         if out_path.exists():
             print(f"  [SKIP] {file_ref} (already exists)")
             continue
-        ok = False
-        for be in backends:
-            renderer = _RENDERERS.get(be)
-            if renderer and renderer(latex, out_path):
-                print(f"  [OK]   {file_ref} ({be}): {latex}")
-                rendered += 1
-                ok = True
-                break
-        if not ok:
-            print(f"  [FAIL] {file_ref}: all backends failed for '{latex}'",
+        if render_formula(latex, out_path, dpi=dpi):
+            print(f"  [OK]   {file_ref}: {latex}")
+            rendered += 1
+        else:
+            print(f"  [FAIL] {file_ref}: render failed for '{latex}'",
                   file=sys.stderr)
+
+    # Build manifest with dimensions + uniform scale factor
+    manifest_formulas = {}
+    heights: list[int] = []
+    for latex, file_ref in seen.items():
+        out_path = project_path / file_ref
+        if not out_path.exists():
+            continue
+        dims = _image_dimensions(out_path)
+        is_block = next(
+            (ib for _, fr, _, ib in replacements if fr == file_ref), False
+        )
+        entry: dict = {"latex": latex, "type": "block" if is_block else "inline"}
+        if dims:
+            entry["width"] = dims[0]
+            entry["height"] = dims[1]
+            heights.append(dims[1])
+        manifest_formulas[file_ref] = entry
+
+    # Uniform scale factor: all formulas use the SAME scale so letter sizes
+    # stay consistent.  Based on tallest formula → target display height.
+    max_h = max(heights) if heights else 1
+    target_display_height = 50  # px in SVG coordinate space
+    uniform_scale = round(target_display_height / max_h, 4)
+
+    manifest_path = latex_dir / _MANIFEST_NAME
+    manifest = {
+        "dpi": dpi,
+        "uniform_scale": uniform_scale,
+        "target_display_height": target_display_height,
+        "max_source_height": max_h,
+        "_comment": "Apply uniform_scale to ALL formula images so letter sizes stay consistent. Display size = source_size * uniform_scale.",
+        "formulas": manifest_formulas,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False),
+                             encoding="utf-8")
 
     # Build set of formulas with valid PNGs
     rendered_ok: set[str] = set()
@@ -179,7 +189,7 @@ def process_spec_lock(
     # Replace only formulas whose PNG exists on disk
     new_text = text
     replaced = 0
-    for full_match, file_ref, latex in replacements:
+    for full_match, file_ref, latex, _ in replacements:
         if latex in rendered_ok:
             new_text = new_text.replace(full_match, f"![]({file_ref})", 1)
             replaced += 1
@@ -190,6 +200,7 @@ def process_spec_lock(
     if replaced > 0:
         spec_lock.write_text(new_text, encoding="utf-8")
     print(f"\nRendered {rendered} formula(s), replaced {replaced} in spec_lock.md.")
+    print(f"Manifest saved to {manifest_path}")
     return rendered
 
 
@@ -208,10 +219,10 @@ def main(argv: list[str] | None = None) -> int:
         help="Show what would be rendered without modifying files.",
     )
     parser.add_argument(
-        "--backend",
-        choices=("auto", "codecogs", "matplotlib"),
-        default="auto",
-        help="Rendering backend. 'auto' tries codecogs then matplotlib (default).",
+        "--dpi",
+        type=int,
+        default=300,
+        help="Rendering DPI (default: 300). Higher = larger output images.",
     )
     args = parser.parse_args(argv)
 
@@ -220,7 +231,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Error: {project} is not a directory.", file=sys.stderr)
         return 1
 
-    return 0 if process_spec_lock(project, dry_run=args.dry_run, backend=args.backend) >= 0 else 1
+    return 0 if process_spec_lock(project, dry_run=args.dry_run, dpi=args.dpi) >= 0 else 1
 
 
 if __name__ == "__main__":

--- a/skills/ppt-master/templates/spec_lock_reference.md
+++ b/skills/ppt-master/templates/spec_lock_reference.md
@@ -41,6 +41,7 @@
 > **All five family lines are listed explicitly** so Strategist considers every role — `code_family` and `emphasis_family` are easily forgotten. In a real `spec_lock.md`:
 > - Keep any `*_family` whose role genuinely differs from `font_family`.
 > - **Omit** any `*_family` equal to `font_family` — Executor falls back to `font_family` for missing roles, so writing it twice is noise. (Exception: keep `code_family` even when equal — monospace is conceptually distinct.)
+> - **`code_family` applies to code snippets only**. LaTeX formulas are NOT rendered with this font — they are pre-rendered to transparent PNG images by `latex_render.py` (Step 4.5) and placed as `<image>` elements.
 >
 > `font_family` is the default fallback. Every declared family is a CSS font-stack string.
 >


### PR DESCRIPTION
## Summary

Add LaTeX formula rendering support to the PPT generation pipeline. Formulas written in `spec_lock.md` using `$...$` (inline) or `$$...$$` (block) syntax are automatically rendered to transparent PNG images via the CodeCogs online LaTeX API.

### Before / After

<img width="1219" height="645" alt="Snipaste_2026-05-23_10-19-13" src="https://github.com/user-attachments/assets/f291db5d-a45e-41ff-a2ef-f44c80fc2b2a" />
<img width="1108" height="697" alt="Snipaste_2026-05-23_10-19-44" src="https://github.com/user-attachments/assets/c8667a05-6c52-4224-93b8-ae6f6d13aaa0" />

---

### Changes

**New: `scripts/latex_render.py`**
- Pure CodeCogs API backend — no local LaTeX installation required
- Extracts `$...$` and `$$...$$` formulas from `spec_lock.md`
- Renders each unique formula to `images/latex/F*.png`
- Generates `images/latex/manifest.json` with:
  - `uniform_scale`: single scale factor based on tallest formula → target display height (50px), ensuring letter sizes stay consistent across all formulas
  - Per-formula dimensions and type (inline/block)
- Supports `--dry-run` (preview without rendering) and `--dpi` (default 300)

**Modified: `SKILL.md`**
- Added Step 4.5 between Step 4 and Step 5 for the LaTeX rendering step

**Modified: `references/strategist.md`**
- LaTeX formula identification rule: formulas are pre-rendered PNG images, not text rendered with any font stack
- Typography System chapter clarifies formula images align with surrounding typography via `manifest.json` `uniform_scale`

**Modified: `references/executor-base.md`**
- Formula images placed as `<image>` elements using `uniform_scale` from manifest
- Clarified formulas are not a font-stack role

**Modified: `templates/spec_lock_reference.md`**
- `code_family` applies to code snippets only; LaTeX formulas are pre-rendered PNG images

**Modified: `CLAUDE.md`**
- Added `latex_render.py` commands to Command Quick Reference

### Key Design Decision: `uniform_scale`

All formula images share a single scale factor rather than being normalized to the same height individually. Normalizing heights would break letter size consistency — a short formula like $E=mc^2$ would have its letters enlarged to match the tallest formula's height, making it visually inconsistent with surrounding text. The uniform scale factor preserves the original relative sizes.