### PR TITLE
fix(svg): require width+height+viewBox on SVG root element

### DIFF
--- a/skills/ppt-master/references/shared-standards.md
+++ b/skills/ppt-master/references/shared-standards.md
@@ -169,7 +169,7 @@ One offending character invalidates the file and aborts export. Numeric refs (`&
 
 ## 4. Basic SVG Rules
 
-- **viewBox** must match the canvas dimensions (`width`/`height` must match `viewBox`)
+- **SVG root element MUST include `width`, `height`, and `viewBox`** — all three attributes are required on every `<svg>` tag. Values must be identical: `width="1280" height="720" viewBox="0 0 1280 720"`. Omitting `width`/`height` causes browser preview and some SVG renderers to display the slide at incorrect size.
 - **Background**: Use `<rect>` to define the page background color
 - **`<tspan>`** has two purposes: (1) manual line breaks (use `dy` or explicit `y`); (2) inline run formatting on the same line (color/weight/size). `<foreignObject>` is FORBIDDEN. See "Single logical line" rule below.
 - **Fonts**: every `font-family` stack MUST end with a pre-installed family (Microsoft YaHei / SimSun / Arial / Times New Roman / Consolas …); `@font-face` is FORBIDDEN. Full rule: [`strategist.md §g`](strategist.md).

--- a/skills/ppt-master/scripts/svg_quality_checker.py
+++ b/skills/ppt-master/scripts/svg_quality_checker.py
@@ -19,6 +19,8 @@ from typing import List, Dict, Tuple
 from collections import defaultdict
 from xml.etree import ElementTree as ET
 
+SVG_NS = "http://www.w3.org/2000/svg"
+
 try:
     from project_utils import CANVAS_FORMATS
     from error_helper import ErrorHelper


### PR DESCRIPTION
## Summary

SVG root elements must include `width`, `height`, and `viewBox` — all three attributes are required. Omitting `width`/`height` causes browser preview and some SVG renderers to display slides at incorrect size.

### Changes

**Modified: `references/shared-standards.md`**
- Updated §4 SVG rule: `viewBox must match canvas dimensions` → explicit requirement that all three attributes (`width`, `height`, `viewBox`) must be present with identical values

**Modified: `scripts/svg_quality_checker.py`**
- Added missing `SVG_NS = "http://www.w3.org/2000/svg"` constant used for namespace-aware XML parsing