### PR TITLE
feat(native-diagram): recolor / text-fill / font transforms

### DIFF
--- a/skills/ppt-master/references/native-diagrams.md
+++ b/skills/ppt-master/references/native-diagrams.md
@@ -1,0 +1,117 @@
+# Native Diagrams — Selection & Placement Reference
+
+> Lazy-loaded reference. Load **only** when `spec_lock.md page_diagrams` has at
+> least one entry (Strategist matched a page to a native diagram). If that section
+> is empty/absent, this file is never read. Peer to [`image-generator.md`](./image-generator.md)
+> and the chart catalog — same "scan an index, match by content shape" pattern.
+
+A **native diagram** is a pre-designed, fully-editable DrawingML figure lifted
+verbatim from a real deck and stored in `templates/native_diagrams/`. Unlike a
+`templates/charts/` SVG (which Executor *redraws* from scratch using the template
+as reference), a native diagram is **spliced in as-is** via a placeholder and only
+recolored — so an elaborate, polished figure arrives pixel-faithful and still
+native-editable, at near-zero authoring cost.
+
+---
+
+## 1. When a native diagram is the right vehicle (vs the alternatives)
+
+For any page whose content is a *structural relationship* (hierarchy / flow /
+convergence / comparison / composition / cycle), there are four vehicles. Pick by
+content-shape **and** the deck's visual ambition (set once in §d Style Objective):
+
+| Vehicle | Use when |
+|---|---|
+| Native diagram | The relationship maps to a polished, dimensional figure. Spliced in as-is + recolored to the deck palette — any deck can use it once recolored; keep the treatment consistent across the deck's structural pages. |
+| `charts/` SVG template | The deck is flat / minimalist, OR the figure needs structural surgery (different slot count, custom axes) the native diagram can't flex to. |
+| Hand-drawn SVG | No catalog entry fits; the page wants a bespoke layout. |
+| AI image (`image-generator`) | The page wants atmosphere / a scene / a hero, not an editable structural figure. |
+
+> **Visual-cohesion guardrail**: Native diagrams carry a deliberate **3D /
+> dimensional idiom** — recolor adapts their *color* to the deck palette, but the
+> glossy/volumetric *treatment* stays. There is **no hard style gate** (recolored,
+> they drop into any deck); it is a soft cohesion call — once you use them, use them
+> **consistently** across the deck's structural pages rather than scattering a single
+> glossy figure into otherwise-flat pages. Strategist sets this direction once, from
+> §d Style Objective, before matching pages.
+
+---
+
+## 2. Selecting a specific diagram
+
+Source of truth: [`templates/native_diagrams/diagrams_index.json`](../templates/native_diagrams/diagrams_index.json),
+shape `{ meta, diagrams }`. Scan the `diagrams.*.pick` lines in one pass (same as
+the chart catalog) and match each candidate page by:
+
+1. **`scenario`** (content-first — start here) — the business content the figure
+   serves: *capability map / maturity model / platform or tech stack / roadmap /
+   two-sided platform / module portfolio …*. A PPT expert thinks in scenarios first
+   ("I'm making a capability-hub page"), then narrows by structure.
+2. **`type` / `use`** — the underlying relationship: `framework` (hub-spoke) /
+   `funnel` / `pyramid` / `layered-platform` / `isometric-stack` / `matrix` /
+   `cycle` / `list-row` / `timeline` / `bowtie` (hourglass converge-diverge).
+3. **`slots` / `slot_of`** — item count **and what the count means**: `slot_of`
+   encodes the parallel grain — `columns` (N-栏 comparison) / `tiers` / `layers` /
+   `spokes` / `cells`. Match the page's item count to the range.
+4. **`holds`** — does the content per item fit? `short-label` figures break if you
+   have a sentence per node; use a `label+desc` figure for richer items.
+5. **`footprint`** — the figure's natural region shape, for *where* it goes:
+   `wide-band` (a horizontal strip — needs full width, not a narrow column) /
+   `tall-center` (pyramid/funnel/tower — fits a half-width column) /
+   `centered-compact` (a hub concentrated mid-slide — flexible region) /
+   `full-bleed` (panorama/architecture — full-slide only). Match it to the slide
+   region you've reserved.
+6. **`density`** — how small it can shrink and stay legible: `low` works as an
+   in-page element; `high` needs most of the slide (see §3).
+7. **`text_load`** — overall copy the figure carries: `light` (labels only) /
+   `medium` / `heavy` (text in every cell). Match to page rhythm — a `breathing`
+   page wants `light`; a `dense` page can take `heavy`.
+8. **`motif`** — node vocabulary (`sphere` / `card` / `cube` / `ring` / `tower` /
+   `pyramid` / `mixed`). Prefer one that echoes the deck's other elements (a
+   card-based deck pairs with a `card`/`cube` motif, not glossy spheres).
+9. **`conf`** — `refined` = hand-verified distinguishing entry (trust it);
+   `high` = studied; `approx` = contact-sheet read — sanity-check the thumbnail in
+   `gallery.html` before relying on an `approx` pick.
+
+> **Distinguishing within a type** (e.g. choosing among many `framework`s): rely on
+> `subform` + `distinct` + the differentiated `pick` (refined entries cross-reference
+> siblings — "Skip if radial hub (031)"). `type` alone does not discriminate.
+
+Skip `selectable: false` entries (cover / notice / table). One native diagram per
+page (it is the page's primary figure).
+
+---
+
+## 3. Placing it (Executor) — the `data-native-diagram` placeholder
+
+Native diagrams are resolved at SVG→PPTX conversion time (peer to `<use data-icon>`
+and `<image>`). Executor writes a placeholder rect; the converter splices the
+component in, scaled to the rect.
+
+> Resolver: [`native_diagram_resolver.py`](../scripts/svg_to_pptx/native_diagram_resolver.py).
+
+```xml
+<rect data-native-diagram="<key>"
+      x=".." y=".." width=".." height=".." fill="none"/>
+```
+
+- **`data-native-diagram`** = the chosen `<key>` from `page_diagrams`.
+- **Region sizing by `density`**: `high` → near-full-slide (respect canvas margins);
+  `medium` → ≥ half-slide; `low` → may be a smaller region. The whole figure
+  (including its text) scales to the rect — so do **not** shrink a text-bearing
+  diagram into a tiny region or its labels become illegible. When in doubt, give it
+  the page.
+- The rect itself does not render (it's replaced); keep `fill="none"` (a dashed
+  light stroke is fine as a preview marker). The figure only appears in the PPTX,
+  not in the SVG preview.
+
+---
+
+## 4. Limits
+
+- **Charts not lifted** — entries are diagram/figure structures only; data charts
+  (`graphicFrame`) stay with `templates/charts/`.
+- **No structural surgery** — you cannot add a tier or remove a spoke; the figure is
+  frozen. If the content needs a different slot count, pick a different `key` or use
+  a `charts/` template.
+- **Composed assets** (`type: composite`) are pre-combined figures — use as-is.

--- a/skills/ppt-master/references/native-diagrams.md
+++ b/skills/ppt-master/references/native-diagrams.md
@@ -86,16 +86,39 @@ page (it is the page's primary figure).
 
 Native diagrams are resolved at SVG→PPTX conversion time (peer to `<use data-icon>`
 and `<image>`). Executor writes a placeholder rect; the converter splices the
-component in, scaled to the rect.
+component in, scaled to the rect, recolored, and re-fonted to the deck.
 
 > Resolver: [`native_diagram_resolver.py`](../scripts/svg_to_pptx/native_diagram_resolver.py).
 
 ```xml
 <rect data-native-diagram="<key>"
+      data-recolor="558C5A=<spec_lock primary>,122B87=<spec_lock accent>"
+      data-font="<spec_lock typography.font_family — FIRST family only>"
+      data-text='{"0":"<your title>","1":"<your label>", "2":"..."}'
       x=".." y=".." width=".." height=".." fill="none"/>
 ```
 
 - **`data-native-diagram`** = the chosen `<key>` from `page_diagrams`.
+- **`data-font`** (always set it) = the **first family name** from `spec_lock`
+  `typography.font_family` (e.g. `Microsoft YaHei`) — a single typeface, **not** the
+  full CSS stack (`"Microsoft YaHei", Arial, sans-serif`). DrawingML's `typeface`
+  takes one font name; the converter also reduces a stack to its first family as a
+  safety net. Components carry the **source deck's** fonts, and most runs name no
+  typeface and inherit the slide theme — so without this the figure's text renders
+  in a different font than the surrounding SVG text.
+- **`data-recolor`** = remap the diagram's two base hexes (`meta.recolor_base`:
+  `558C5A` primary, `122B87` accent) onto **this deck's** `spec_lock.colors`
+  primary/accent. The 3D shading re-derives from the new base. If the deck has only
+  one accent, map both bases to tints of it. Each side is one 6-digit hex.
+- **`data-text`** (put YOUR content in the figure) = a JSON object
+  `{"<slot_id>": "<text>"}`. **First `read_file templates/native_diagrams/<key>/meta.json`**
+  and look at `text_slots` — each slot is `{id, text}` where `text` is the
+  source's original label (your *hint* for what that slot holds). Slot id is the
+  run's **document order, NOT visual reading order** — so map your content to slot
+  ids by matching the original `text` (e.g. the slot whose original text is the
+  centre label gets your centre label). Provide only the slots you want to change;
+  unprovided slots keep the source text. If a diagram's labels don't all map
+  cleanly, fill what you can and relabel the rest in PowerPoint after export.
 - **Region sizing by `density`**: `high` → near-full-slide (respect canvas margins);
   `medium` → ≥ half-slide; `low` → may be a smaller region. The whole figure
   (including its text) scales to the rect — so do **not** shrink a text-bearing

--- a/skills/ppt-master/scripts/native_diagrams/__init__.py
+++ b/skills/ppt-master/scripts/native_diagrams/__init__.py
@@ -1,0 +1,21 @@
+"""Native-diagram library: lift editable DrawingML diagrams between decks.
+
+Unlike the SVG pipeline (``pptx_to_svg`` -> ``svg_to_pptx``), this package never
+re-renders. It lifts a slide's ``<p:sp>`` / ``<p:grpSp>`` XML verbatim and only
+flattens theme dependencies (``schemeClr`` -> ``srgbClr``, theme fonts ->
+typefaces) so the diagram is pixel-identical AND natively editable in any deck.
+
+This module owns the shared component-format primitives (theme flattening). The
+``extract_diagram`` / ``inject_diagram`` tools build on top of them (extract-inject
+tooling layer).
+
+See ``references/native-diagrams.md`` for the placeholder contract consumed by the
+SVG→PPTX converter.
+"""
+from .component import ThemeMaps, flatten_theme, load_theme_maps
+
+__all__ = [
+    "load_theme_maps",
+    "flatten_theme",
+    "ThemeMaps",
+]

--- a/skills/ppt-master/scripts/native_diagrams/component.py
+++ b/skills/ppt-master/scripts/native_diagrams/component.py
@@ -1,0 +1,235 @@
+"""Shared helpers for the native-diagram library: theme flattening + rel resolution.
+
+A **native diagram** is a self-contained, theme-independent DrawingML shape group
+lifted verbatim out of a source ``.pptx`` slide. Unlike the SVG round-trip
+(``pptx_to_svg`` -> ``svg_to_pptx``), nothing is re-rendered: the original
+``<p:sp>`` / ``<p:grpSp>`` XML is kept byte-for-byte, so decorative flourishes
+(bezier flow arrows, halftone dot patterns, gradient 3D shading) survive intact
+while the shapes stay natively editable in PowerPoint.
+
+The single transform applied is **theme flattening**. Source decks express most
+colors as ``<a:schemeClr>`` (theme references) and fonts as ``+mj-ea`` / ``+mn-lt``
+tokens. Pasted into a deck with a different theme those would recolor / re-font.
+Flattening resolves every ``schemeClr`` -> ``srgbClr`` (through the slide master's
+``clrMap`` and the theme's color scheme) and every theme-font token -> its concrete
+typeface, so the component renders identically in ANY deck.
+
+Modifier children of ``schemeClr`` (``lumMod`` / ``lumOff`` / ``shade`` / ``tint``
+/ ``alpha`` / ``satMod`` …) are preserved untouched — they carry the gradient and
+3D-shading math, and DrawingML accepts them on ``srgbClr`` just as on ``schemeClr``.
+"""
+from __future__ import annotations
+
+import posixpath
+from dataclasses import dataclass
+from lxml import etree
+
+A = "http://schemas.openxmlformats.org/drawingml/2006/main"
+P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+PR = "http://schemas.openxmlformats.org/package/2006/relationships"
+NS = {"a": A, "p": P, "r": R}
+
+# Top-level slide-shape kinds we lift. Everything else under spTree (the group's
+# own nvGrpSpPr / grpSpPr props) is slide scaffolding, not diagram content.
+SHAPE_TAGS = frozenset(
+    {"sp", "grpSp", "pic", "graphicFrame", "cxnSp", "contentPart"}
+)
+
+REL_BASE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/"
+IMAGE_REL = REL_BASE + "image"
+CHART_REL = REL_BASE + "chart"
+LAYOUT_REL = REL_BASE + "slideLayout"
+MASTER_REL = REL_BASE + "slideMaster"
+THEME_REL = REL_BASE + "theme"
+
+
+def local(elem) -> str:
+    """Local tag name without the namespace brace."""
+    return etree.QName(elem).localname
+
+
+# ---------------------------------------------------------------------------
+# Relationship resolution (walk slide -> layout -> master -> theme)
+# ---------------------------------------------------------------------------
+
+def rels_path(part: str) -> str:
+    """``ppt/slides/slide1.xml`` -> ``ppt/slides/_rels/slide1.xml.rels``."""
+    d = posixpath.dirname(part)
+    return posixpath.join(d, "_rels", posixpath.basename(part) + ".rels")
+
+
+def read_rels(zf, part: str) -> list[dict]:
+    """Return the relationship records for *part* (empty list if it has none)."""
+    try:
+        data = zf.read(rels_path(part))
+    except KeyError:
+        return []
+    root = etree.fromstring(data)
+    out = []
+    for rel in root:
+        out.append(
+            {
+                "id": rel.get("Id"),
+                "type": rel.get("Type"),
+                "target": rel.get("Target"),
+                "mode": rel.get("TargetMode"),
+            }
+        )
+    return out
+
+
+def resolve_target(part: str, target: str) -> str:
+    """Resolve a (possibly ``../``-relative) rel target to an absolute zip path."""
+    if target.startswith("/"):
+        return target.lstrip("/")
+    return posixpath.normpath(posixpath.join(posixpath.dirname(part), target))
+
+
+def first_target(zf, part: str, rel_type: str) -> str | None:
+    for rel in read_rels(zf, part):
+        if rel["type"] == rel_type:
+            return resolve_target(part, rel["target"])
+    return None
+
+
+def resolve_master_and_theme(zf, slide_part: str) -> tuple[str, str]:
+    """Walk slide -> layout -> master -> theme. Falls back to ``*1`` parts."""
+    layout = first_target(zf, slide_part, LAYOUT_REL) or "ppt/slideLayouts/slideLayout1.xml"
+    master = first_target(zf, layout, MASTER_REL) or "ppt/slideMasters/slideMaster1.xml"
+    theme = first_target(zf, master, THEME_REL) or "ppt/theme/theme1.xml"
+    return master, theme
+
+
+# ---------------------------------------------------------------------------
+# Theme flattening
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ThemeMaps:
+    colors: dict   # theme slot -> hex  (dk1 / lt1 / dk2 / lt2 / accent1..6 / hlink / folHlink)
+    clrmap: dict   # bg1 / tx1 / bg2 / tx2 / accent1.. -> theme slot (per the slide master)
+    fonts: dict    # +mj-ea / +mn-lt / … -> concrete typeface
+
+    def resolve_color(self, val: str) -> str | None:
+        """``schemeClr`` val -> hex. Honors the (sometimes inverted) clrMap."""
+        if val in self.clrmap:          # bg1 / tx1 / bg2 / tx2 indirect through clrMap
+            return self.colors.get(self.clrmap[val])
+        return self.colors.get(val)     # accent1..6 / dk1 / lt1 … used directly
+
+
+def load_theme_maps(theme_xml: bytes, master_xml: bytes) -> ThemeMaps:
+    theme = etree.fromstring(theme_xml)
+    master = etree.fromstring(master_xml)
+
+    colors: dict[str, str] = {}
+    for c in theme.find(".//a:clrScheme", NS):
+        srgb = c.find("a:srgbClr", NS)
+        sysc = c.find("a:sysClr", NS)
+        if srgb is not None:
+            colors[local(c)] = srgb.get("val")
+        elif sysc is not None:
+            colors[local(c)] = sysc.get("lastClr")
+
+    clrmap_el = master.find("p:clrMap", NS)
+    clrmap = dict(clrmap_el.attrib) if clrmap_el is not None else {}
+
+    fs = theme.find(".//a:fontScheme", NS)
+    mj = fs.find("a:majorFont", NS)
+    mn = fs.find("a:minorFont", NS)
+
+    def typeface(font_el, script: str) -> str | None:
+        e = font_el.find("a:" + script, NS)
+        return e.get("typeface") if (e is not None and e.get("typeface")) else None
+
+    fonts = {
+        "+mj-lt": typeface(mj, "latin"),
+        "+mn-lt": typeface(mn, "latin"),
+        "+mj-ea": typeface(mj, "ea") or typeface(mj, "latin"),
+        "+mn-ea": typeface(mn, "ea") or typeface(mn, "latin"),
+        "+mj-cs": typeface(mj, "cs"),
+        "+mn-cs": typeface(mn, "cs"),
+    }
+    return ThemeMaps(colors=colors, clrmap=clrmap, fonts=fonts)
+
+
+def strip_foreign_rels(sp_tree, keep_rids: set) -> int:
+    """Remove relationship references the component does not carry.
+
+    Lifted shapes routinely point at parts that don't travel with a diagram:
+    ``<p:custDataLst><p:tags r:id>`` (vendor tag parts), hyperlinks, sounds.
+    Left in place, those ``r:id`` / ``r:embed`` values dangle in the target deck
+    and PowerPoint rejects the file as corrupt. *keep_rids* are the media rIds
+    that ``inject`` will remap; everything else is stripped. Returns the count
+    of removed refs/elements.
+    """
+    removed = 0
+    # custDataLst holds <p:tags r:id="..."> pointing at tag parts we don't carry.
+    for cd in list(sp_tree.iter("{%s}custDataLst" % P)):
+        parent = cd.getparent()
+        if parent is not None:
+            parent.remove(cd)
+            removed += 1
+
+    rid_attrs = ("{%s}embed" % R, "{%s}link" % R, "{%s}id" % R)
+    drop_elems = {"hlinkClick", "hlinkHover", "tags", "snd"}
+    for el in list(sp_tree.iter()):
+        for attr in rid_attrs:
+            v = el.get(attr)
+            if v is not None and v not in keep_rids:
+                if local(el) in drop_elems:
+                    parent = el.getparent()
+                    if parent is not None:
+                        parent.remove(el)
+                        removed += 1
+                else:
+                    del el.attrib[attr]
+                    removed += 1
+                break
+    return removed
+
+
+def recolor_shapes(root, color_map: dict) -> int:
+    """Remap explicit ``srgbClr`` hex values in-place (case-insensitive).
+
+    Because the library flattens theme colors to a tiny set of base hexes (the
+    source accents) plus shading modifiers (``lumMod`` / ``shade`` …) that are
+    *kept*, a whole-diagram palette swap is just a base-hex remap: replacing
+    ``558C5A`` -> a new green re-derives every gradient/3D tint from the new base.
+
+    *color_map*: ``{"558C5A": "0E7C7B", ...}`` (``#`` optional, case-insensitive).
+    Returns the number of fills changed.
+    """
+    cmap = {k.upper().lstrip("#"): v.upper().lstrip("#") for k, v in color_map.items()}
+    n = 0
+    for el in root.iter("{%s}srgbClr" % A):
+        v = (el.get("val") or "").upper()
+        if v in cmap:
+            el.set("val", cmap[v])
+            n += 1
+    return n
+
+
+def flatten_theme(sp_tree, maps: ThemeMaps) -> dict:
+    """In-place: ``schemeClr`` -> ``srgbClr`` and theme-font tokens -> typeface.
+
+    Returns a counts dict for reporting / verification.
+    """
+    n_clr = n_skip = 0
+    for sc in list(sp_tree.iter("{%s}schemeClr" % A)):
+        hexv = maps.resolve_color(sc.get("val"))
+        if hexv:
+            sc.tag = "{%s}srgbClr" % A   # children (lumMod/shade/…) are kept verbatim
+            sc.set("val", hexv)
+            n_clr += 1
+        else:
+            n_skip += 1  # e.g. phClr — leave untouched
+
+    n_font = 0
+    for el in sp_tree.iter():
+        tf = el.get("typeface")
+        if tf in maps.fonts and maps.fonts[tf]:
+            el.set("typeface", maps.fonts[tf])
+            n_font += 1
+
+    return {"colors": n_clr, "colors_unresolved": n_skip, "fonts": n_font}

--- a/skills/ppt-master/scripts/svg_to_pptx/drawingml_converter.py
+++ b/skills/ppt-master/scripts/svg_to_pptx/drawingml_converter.py
@@ -363,6 +363,27 @@ def convert_element(elem: ET.Element, ctx: ConvertContext) -> ShapeResult | None
         event.update(metadata)
         ctx.trace_events.append(event)
 
+    # Native-diagram placeholder: an element (typically <rect>) carrying
+    # data-native-diagram is resolved by splicing the named component's
+    # DrawingML in, scaled to the placeholder rect — peer to <use data-icon>
+    # and <image>. Intercept before the normal tag dispatch so the placeholder
+    # rect never reaches convert_rect.
+    if elem.get('data-native-diagram'):
+        from .native_diagram_resolver import resolve_native_diagram
+        try:
+            result = resolve_native_diagram(elem, ctx)
+        except SvgNativeConversionError:
+            trace('error', error='native-diagram resolve failed')
+            raise  # already a precise native-diagram error; don't double-wrap
+        except Exception as e:
+            trace('error', error=str(e))
+            raise SvgNativeConversionError(
+                f"Failed to resolve data-native-diagram="
+                f"{elem.get('data-native-diagram')!r}: {e}"
+            ) from e
+        trace('native-diagram', key=elem.get('data-native-diagram'))
+        return result
+
     converter = _CONVERTERS.get(tag)
     if converter:
         try:

--- a/skills/ppt-master/scripts/svg_to_pptx/native_diagram_resolver.py
+++ b/skills/ppt-master/scripts/svg_to_pptx/native_diagram_resolver.py
@@ -1,0 +1,135 @@
+"""Resolve ``data-native-diagram`` placeholders into spliced DrawingML.
+
+This makes native-diagram components a first-class peer of ``<use data-icon>``
+and ``<image>`` in the SVG -> DrawingML pipeline. The Executor draws a placeholder
+rect in the SVG::
+
+    <rect data-native-diagram="combo_product_system"
+          x="140" y="120" width="1000" height="480" fill="none"/>
+
+and at conversion time the named component's shapes (already DrawingML) are
+spliced in, scaled to the placeholder rect.
+
+Splicing is string-based (not ElementTree) so the component's namespace prefixes
+(``a`` / ``p`` / ``r`` / ``a14`` / ``a16`` / …) stay byte-exact: the stored
+``<a:diagram ...>`` wrapper — which carries every ``xmlns`` declaration — is
+rewritten into a ``<p:grpSp ...>`` wrapper, keeping those declarations intact.
+
+This module owns the core splice path (scale + media-remap + id-renumber). The
+recolor / text-substitution / font-normalisation transforms layer on top via the
+``data-recolor`` / ``data-text`` / ``data-font`` attributes.
+
+See ``references/native-diagrams.md`` for the placeholder attribute contract.
+"""
+from __future__ import annotations
+
+import gzip
+import json
+import re
+import sys
+from pathlib import Path
+
+from .drawingml_context import ConvertContext, ShapeResult
+from .drawingml_utils import ctx_x, ctx_y, ctx_w, ctx_h, px_to_emu
+
+LIB_DIR = Path(__file__).resolve().parent.parent.parent / "templates" / "native_diagrams"
+IMAGE_REL = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"
+
+
+def _f(v) -> float:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _renumber_cnvpr(xml: str, ctx: ConvertContext) -> str:
+    """Reassign every ``<p:cNvPr id>`` from the slide's id allocator (unique)."""
+    return re.sub(
+        r'(<p:cNvPr id=")\d+(")',
+        lambda m: f"{m.group(1)}{ctx.next_id()}{m.group(2)}",
+        xml,
+    )
+
+
+def _remap_media(xml: str, comp_dir: Path, media_map: dict, ctx: ConvertContext) -> str:
+    """Register each referenced bitmap on the slide and remap its ``r:embed``."""
+    for old_rid, rel_path in media_map.items():
+        fpath = comp_dir / rel_path
+        if not fpath.exists():
+            continue
+        ext = fpath.suffix.lstrip(".").lower()
+        if ext == "jpeg":
+            ext = "jpg"
+        fname = f"s{ctx.slide_num}_nd{len(ctx.media_files) + 1}.{ext}"
+        ctx.media_files[fname] = fpath.read_bytes()
+        new_rid = ctx.next_rel_id()
+        ctx.rel_entries.append(
+            {"id": new_rid, "type": IMAGE_REL, "target": f"../media/{fname}"}
+        )
+        xml = re.sub(r'(r:(?:embed|link)=")' + re.escape(old_rid) + r'(")',
+                     r"\g<1>" + new_rid + r"\g<2>", xml)
+    return xml
+
+
+def resolve_native_diagram(elem, ctx: ConvertContext) -> ShapeResult | None:
+    """Splice the referenced component, scaled into the placeholder rect."""
+    from .drawingml_converter import SvgNativeConversionError
+
+    key = elem.get("data-native-diagram")
+    comp_dir = LIB_DIR / key
+    # A key is authored, not user input — but a malformed value that escapes the
+    # library directory must fail loudly, never read an arbitrary file.
+    if not comp_dir.resolve().is_relative_to(LIB_DIR.resolve()):
+        raise SvgNativeConversionError(
+            f"data-native-diagram key escapes the library: {key!r} "
+            f"(use a bare component name)"
+        )
+    gz, plain = comp_dir / "shapes.xml.gz", comp_dir / "shapes.xml"
+    if gz.exists():
+        xml = gzip.decompress(gz.read_bytes()).decode("utf-8")
+    elif plain.exists():
+        xml = plain.read_text(encoding="utf-8")
+    else:
+        raise SvgNativeConversionError(f"data-native-diagram: component not found: {key}")
+    meta = json.loads((comp_dir / "meta.json").read_text(encoding="utf-8"))
+
+    # Placeholder geometry -> EMU target rect (honours the context transform).
+    x = ctx_x(_f(elem.get("x")), ctx)
+    y = ctx_y(_f(elem.get("y")), ctx)
+    w = ctx_w(_f(elem.get("width")), ctx)
+    h = ctx_h(_f(elem.get("height")), ctx)
+    if w <= 0 or h <= 0:
+        print(
+            f"Warning: data-native-diagram={key!r} skipped — zero placeholder size "
+            f"(w={w}, h={h}); check the rect's width/height.",
+            file=sys.stderr,
+        )
+        return None
+    off_x, off_y = px_to_emu(x), px_to_emu(y)
+    ext_cx, ext_cy = px_to_emu(w), px_to_emu(h)
+    ch_cx, ch_cy = meta["canvas_emu"]
+
+    xml = re.sub(r"^\s*<\?xml[^>]*\?>\s*", "", xml, count=1)
+    if meta.get("media"):
+        xml = _remap_media(xml, comp_dir, meta["media"], ctx)
+    xml = _renumber_cnvpr(xml, ctx)
+
+    # Rewrite <a:diagram ...> -> <p:grpSp ...> (keep its xmlns decls) + group props.
+    m = re.match(r"<a:diagram\b([^>]*)>", xml)
+    if not m:
+        raise SvgNativeConversionError(f"data-native-diagram: malformed component {key}")
+    ns_attrs = m.group(1)
+    gid = ctx.next_id()
+    props = (
+        f'<p:nvGrpSpPr><p:cNvPr id="{gid}" name="NativeDiagram {gid}"/>'
+        f"<p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>"
+        f'<p:grpSpPr><a:xfrm><a:off x="{off_x}" y="{off_y}"/>'
+        f'<a:ext cx="{ext_cx}" cy="{ext_cy}"/>'
+        f'<a:chOff x="0" y="0"/><a:chExt cx="{ch_cx}" cy="{ch_cy}"/></a:xfrm></p:grpSpPr>'
+    )
+    body = xml[m.end():].replace("</a:diagram>", "</p:grpSp>")
+    return ShapeResult(
+        xml=f"<p:grpSp{ns_attrs}>{props}{body}",
+        bounds_emu=(off_x, off_y, off_x + ext_cx, off_y + ext_cy),
+    )

--- a/skills/ppt-master/scripts/svg_to_pptx/native_diagram_resolver.py
+++ b/skills/ppt-master/scripts/svg_to_pptx/native_diagram_resolver.py
@@ -5,25 +5,29 @@ and ``<image>`` in the SVG -> DrawingML pipeline. The Executor draws a placehold
 rect in the SVG::
 
     <rect data-native-diagram="combo_product_system"
+          data-recolor="558C5A=0E7C7B,122B87=E8743B"
+          data-font="Microsoft YaHei"
+          data-text='{"0":"My title","1":"My label"}'
           x="140" y="120" width="1000" height="480" fill="none"/>
 
 and at conversion time the named component's shapes (already DrawingML) are
-spliced in, scaled to the placeholder rect.
+spliced in, scaled to the placeholder rect, optionally recolored + text-filled,
+and (with ``data-font``) re-fonted to the deck typeface. Set ``data-font`` to the
+deck's font: components keep the source deck's fonts, and most runs inherit the
+slide theme rather than naming a typeface — so without it the figure's text
+renders in a different font than the surrounding SVG-authored text.
 
 Splicing is string-based (not ElementTree) so the component's namespace prefixes
 (``a`` / ``p`` / ``r`` / ``a14`` / ``a16`` / …) stay byte-exact: the stored
 ``<a:diagram ...>`` wrapper — which carries every ``xmlns`` declaration — is
 rewritten into a ``<p:grpSp ...>`` wrapper, keeping those declarations intact.
 
-This module owns the core splice path (scale + media-remap + id-renumber). The
-recolor / text-substitution / font-normalisation transforms layer on top via the
-``data-recolor`` / ``data-text`` / ``data-font`` attributes.
-
 See ``references/native-diagrams.md`` for the placeholder attribute contract.
 """
 from __future__ import annotations
 
 import gzip
+import html
 import json
 import re
 import sys
@@ -35,12 +39,148 @@ from .drawingml_utils import ctx_x, ctx_y, ctx_w, ctx_h, px_to_emu
 LIB_DIR = Path(__file__).resolve().parent.parent.parent / "templates" / "native_diagrams"
 IMAGE_REL = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"
 
+_HEX_RE = re.compile(r"[0-9A-Fa-f]{6}")
+
 
 def _f(v) -> float:
     try:
         return float(v)
     except (TypeError, ValueError):
         return 0.0
+
+
+def _parse_recolor(spec: str | None) -> dict:
+    """``"558C5A=0E7C7B,122B87=E8743B"`` -> ``{"558C5A": "0E7C7B", ...}``.
+
+    Each side is normalised to a bare 6-digit uppercase hex; a malformed pair is
+    skipped with a warning instead of being injected as an invalid color value.
+    """
+    out: dict[str, str] = {}
+    for pair in (spec or "").split(","):
+        if "=" not in pair:
+            continue
+        old, new = pair.split("=", 1)
+        old = old.strip().lstrip("#").upper()
+        new = new.strip().lstrip("#").upper()
+        if _HEX_RE.fullmatch(old) and _HEX_RE.fullmatch(new):
+            out[old] = new
+        elif pair.strip():
+            print(
+                f"Warning: data-recolor skipped invalid pair {pair.strip()!r} "
+                f"(want SRChex=DSThex, 6 hex digits each)",
+                file=sys.stderr,
+            )
+    return out
+
+
+def _apply_recolor(xml: str, cmap: dict) -> str:
+    """Remap ``<a:srgbClr val="OLD">`` -> NEW in a SINGLE pass.
+
+    One regex over every source hex (resolved through *cmap*) avoids the
+    chained-substitution bug a per-pair loop has: a NEW color equal to some other
+    OLD color would otherwise be re-matched and corrupted by a later pass. Only
+    explicit ``srgbClr`` hexes are remapped; ``schemeClr`` theme refs are left
+    untouched (components are theme-flattened, so their colors are ``srgbClr``).
+    """
+    if not cmap:
+        return xml
+    alternation = "|".join(re.escape(k) for k in cmap)
+    pat = re.compile(r'(<a:srgbClr val=")(' + alternation + r')(")', re.IGNORECASE)
+    return pat.sub(lambda m: m.group(1) + cmap[m.group(2).upper()] + m.group(3), xml)
+
+
+_AT_RE = re.compile(r"<a:t>(.*?)</a:t>", re.DOTALL)
+
+
+def _apply_text_fills(xml: str, data_text: str | None) -> str:
+    """Replace the diagram's text runs with deck content.
+
+    ``data-text`` is a JSON object ``{"<slot_id>": "<new text>"}`` where slot id
+    is the run's index in document order — the same indexing ``extract`` records
+    in ``meta.text_slots``. Slots not provided keep their original (source) text.
+    Non-object JSON (a list / scalar) is ignored, leaving the XML unchanged.
+    """
+    if not data_text:
+        return xml
+    try:
+        fills = json.loads(data_text)
+    except (ValueError, TypeError):
+        return xml
+    if not isinstance(fills, dict) or not fills:
+        return xml
+    counter = [-1]
+
+    def repl(m):
+        counter[0] += 1
+        new = fills.get(str(counter[0]))
+        if new is None:
+            return m.group(0)
+        return "<a:t>%s</a:t>" % html.escape(str(new), quote=False)
+
+    return _AT_RE.sub(repl, xml)
+
+
+_RPR_RE = re.compile(
+    r'<a:(rPr|defRPr|endParaRPr)\b((?:[^>"]|"[^"]*")*?)(?:/>|>(.*?)</a:\1>)',
+    re.DOTALL,
+)
+# Strip an existing typeface child, whether self-closing (<a:latin .../>) or
+# paired (<a:latin ...>...</a:latin>, as PowerPoint emits when it carries extLst).
+_FONT_CHILD_RE = re.compile(
+    r"<a:(?:latin|ea|cs)\b[^>]*/>"
+    r"|<a:(?:latin|ea|cs)\b[^>]*>.*?</a:(?:latin|ea|cs)>",
+    re.DOTALL,
+)
+
+_GENERIC_FAMILIES = {"sans-serif", "serif", "monospace", "cursive", "fantasy", "system-ui"}
+
+
+def _first_family(font: str) -> str:
+    """Reduce a CSS font stack to a single DrawingML typeface.
+
+    ``spec_lock typography.font_family`` is a CSS stack
+    (``"Microsoft YaHei", Arial, sans-serif``), but DrawingML's ``typeface``
+    attribute accepts only ONE font name — feeding it the whole stack produces a
+    malformed PPTX. Take the first concrete family, stripping quotes/whitespace
+    and skipping the generic CSS fallbacks.
+    """
+    for part in font.split(","):
+        name = part.strip().strip('"').strip("'").strip()
+        if name and name.lower() not in _GENERIC_FAMILIES:
+            return name
+    return font.strip().strip('"').strip("'").strip()
+
+
+def _apply_font(xml: str, font: str | None) -> str:
+    """Force the deck font onto every run in the spliced component.
+
+    Native-diagram components carry the source deck's fonts: a few runs name a
+    typeface explicitly, but most carry none and inherit the slide theme's font
+    — which is not the deck font, so the figure's text looks different from the
+    surrounding SVG-authored text. ``data-font`` normalises all of them: existing
+    ``latin``/``ea``/``cs`` are replaced and missing ones injected so every run
+    (and ``endParaRPr``/``defRPr``) renders in the deck's typeface.
+    """
+    if not font:
+        return xml
+    face = _first_family(font)
+    if not face:
+        return xml
+    fonts = (
+        f'<a:latin typeface="{face}"/>'
+        f'<a:ea typeface="{face}"/>'
+        f'<a:cs typeface="{face}"/>'
+    )
+
+    def repl(m):
+        tag, attrs, inner = m.group(1), m.group(2), m.group(3)
+        inner = "" if inner is None else _FONT_CHILD_RE.sub("", inner)
+        return f"<a:{tag}{attrs}>{inner}{fonts}</a:{tag}>"
+
+    xml = _RPR_RE.sub(repl, xml)
+    # Runs that carry text but no run-properties at all get a fresh rPr.
+    xml = re.sub(r"<a:r>(\s*)<a:t>", rf"<a:r><a:rPr>{fonts}</a:rPr>\1<a:t>", xml)
+    return xml
 
 
 def _renumber_cnvpr(xml: str, ctx: ConvertContext) -> str:
@@ -111,6 +251,9 @@ def resolve_native_diagram(elem, ctx: ConvertContext) -> ShapeResult | None:
     ch_cx, ch_cy = meta["canvas_emu"]
 
     xml = re.sub(r"^\s*<\?xml[^>]*\?>\s*", "", xml, count=1)
+    xml = _apply_recolor(xml, _parse_recolor(elem.get("data-recolor")))
+    xml = _apply_text_fills(xml, elem.get("data-text"))
+    xml = _apply_font(xml, elem.get("data-font"))
     if meta.get("media"):
         xml = _remap_media(xml, comp_dir, meta["media"], ctx)
     xml = _renumber_cnvpr(xml, ctx)


### PR DESCRIPTION
Layer the three data-* transforms onto the core splice path: the converter
now recolors, text-fills, and re-fonts a spliced component to match the
deck's spec_lock contract.

What's in this PR
- native_diagram_resolver.py: _apply_recolor (remap base srgbClr hexes from
  data-recolor), _apply_text_fills (substitute <a:t> runs by slot id from
  data-text; slot id = document order, matching meta.text_slots), _apply_font
  (force the deck typeface onto every run from data-font).
- references/native-diagrams.md section 3: the data-recolor / data-text /
  data-font contract.

Blocker fixed (your item 1)
data-font is sourced from spec_lock.typography.font_family, which is a CSS
stack (e.g. "Microsoft YaHei", Arial, sans-serif). DrawingML's typeface
attribute accepts only ONE font name, so writing the stack verbatim produced
a broken PPTX. _first_family() now reduces the stack to its first concrete
family (stripping quotes + generic fallbacks) before it reaches
<a:latin>/<a:ea>/<a:cs>. The doc field path is also corrected
(fonts.font_family -> typography.font_family).

Related fixes (same string-into-XML family)
- recolor runs in a SINGLE pass; a per-pair loop corrupted colors when a
  destination hex equalled another source hex.
- data-text ignores non-object JSON instead of raising AttributeError.
- the font-child strip handles paired <a:latin>...</a:latin>, not only the
  self-closing form.
- data-recolor validates each hex pair, skipping malformed ones with a warning.

Scope: stacked on feat/native-diagram-core. Net-new = the resolver transform
block + native-diagrams.md section 3.
Verified: inline asserts against the real functions (CSS-stack -> single
typeface; single-pass recolor on a cascading map; non-dict data-text no-op;
paired <a:latin> stripped).

---
Stacked on #156 -- please review/merge after it (cross-fork base is `main`, so the diff is cumulative until the parent merges).

---
**6-PR split -- review / merge order** (cross-fork base is `main`, so a child PR's diff is cumulative until its parent merges, then auto-cleans):
1. #156 core
2. #158 text-font (<- #156)  |  #159 engine (<- #156)
3. #160 workflow (<- #158)  |  #161 catalog (<- #159)
4. #157 self-evolution (independent, any time)

The native-diagram asset library is held pending a licensing pass and is not yet opened.