### PR TITLE
feat(native-diagram): batch pack scan + gallery

### DIFF
--- a/skills/ppt-master/references/native-diagrams.md
+++ b/skills/ppt-master/references/native-diagrams.md
@@ -1,0 +1,117 @@
+# Native Diagrams — Selection & Placement Reference
+
+> Lazy-loaded reference. Load **only** when `spec_lock.md page_diagrams` has at
+> least one entry (Strategist matched a page to a native diagram). If that section
+> is empty/absent, this file is never read. Peer to [`image-generator.md`](./image-generator.md)
+> and the chart catalog — same "scan an index, match by content shape" pattern.
+
+A **native diagram** is a pre-designed, fully-editable DrawingML figure lifted
+verbatim from a real deck and stored in `templates/native_diagrams/`. Unlike a
+`templates/charts/` SVG (which Executor *redraws* from scratch using the template
+as reference), a native diagram is **spliced in as-is** via a placeholder and only
+recolored — so an elaborate, polished figure arrives pixel-faithful and still
+native-editable, at near-zero authoring cost.
+
+---
+
+## 1. When a native diagram is the right vehicle (vs the alternatives)
+
+For any page whose content is a *structural relationship* (hierarchy / flow /
+convergence / comparison / composition / cycle), there are four vehicles. Pick by
+content-shape **and** the deck's visual ambition (set once in §d Style Objective):
+
+| Vehicle | Use when |
+|---|---|
+| Native diagram | The relationship maps to a polished, dimensional figure. Spliced in as-is + recolored to the deck palette — any deck can use it once recolored; keep the treatment consistent across the deck's structural pages. |
+| `charts/` SVG template | The deck is flat / minimalist, OR the figure needs structural surgery (different slot count, custom axes) the native diagram can't flex to. |
+| Hand-drawn SVG | No catalog entry fits; the page wants a bespoke layout. |
+| AI image (`image-generator`) | The page wants atmosphere / a scene / a hero, not an editable structural figure. |
+
+> **Visual-cohesion guardrail**: Native diagrams carry a deliberate **3D /
+> dimensional idiom** — recolor adapts their *color* to the deck palette, but the
+> glossy/volumetric *treatment* stays. There is **no hard style gate** (recolored,
+> they drop into any deck); it is a soft cohesion call — once you use them, use them
+> **consistently** across the deck's structural pages rather than scattering a single
+> glossy figure into otherwise-flat pages. Strategist sets this direction once, from
+> §d Style Objective, before matching pages.
+
+---
+
+## 2. Selecting a specific diagram
+
+Source of truth: [`templates/native_diagrams/diagrams_index.json`](../templates/native_diagrams/diagrams_index.json),
+shape `{ meta, diagrams }`. Scan the `diagrams.*.pick` lines in one pass (same as
+the chart catalog) and match each candidate page by:
+
+1. **`scenario`** (content-first — start here) — the business content the figure
+   serves: *capability map / maturity model / platform or tech stack / roadmap /
+   two-sided platform / module portfolio …*. A PPT expert thinks in scenarios first
+   ("I'm making a capability-hub page"), then narrows by structure.
+2. **`type` / `use`** — the underlying relationship: `framework` (hub-spoke) /
+   `funnel` / `pyramid` / `layered-platform` / `isometric-stack` / `matrix` /
+   `cycle` / `list-row` / `timeline` / `bowtie` (hourglass converge-diverge).
+3. **`slots` / `slot_of`** — item count **and what the count means**: `slot_of`
+   encodes the parallel grain — `columns` (N-栏 comparison) / `tiers` / `layers` /
+   `spokes` / `cells`. Match the page's item count to the range.
+4. **`holds`** — does the content per item fit? `short-label` figures break if you
+   have a sentence per node; use a `label+desc` figure for richer items.
+5. **`footprint`** — the figure's natural region shape, for *where* it goes:
+   `wide-band` (a horizontal strip — needs full width, not a narrow column) /
+   `tall-center` (pyramid/funnel/tower — fits a half-width column) /
+   `centered-compact` (a hub concentrated mid-slide — flexible region) /
+   `full-bleed` (panorama/architecture — full-slide only). Match it to the slide
+   region you've reserved.
+6. **`density`** — how small it can shrink and stay legible: `low` works as an
+   in-page element; `high` needs most of the slide (see §3).
+7. **`text_load`** — overall copy the figure carries: `light` (labels only) /
+   `medium` / `heavy` (text in every cell). Match to page rhythm — a `breathing`
+   page wants `light`; a `dense` page can take `heavy`.
+8. **`motif`** — node vocabulary (`sphere` / `card` / `cube` / `ring` / `tower` /
+   `pyramid` / `mixed`). Prefer one that echoes the deck's other elements (a
+   card-based deck pairs with a `card`/`cube` motif, not glossy spheres).
+9. **`conf`** — `refined` = hand-verified distinguishing entry (trust it);
+   `high` = studied; `approx` = contact-sheet read — sanity-check the thumbnail in
+   `gallery.html` before relying on an `approx` pick.
+
+> **Distinguishing within a type** (e.g. choosing among many `framework`s): rely on
+> `subform` + `distinct` + the differentiated `pick` (refined entries cross-reference
+> siblings — "Skip if radial hub (031)"). `type` alone does not discriminate.
+
+Skip `selectable: false` entries (cover / notice / table). One native diagram per
+page (it is the page's primary figure).
+
+---
+
+## 3. Placing it (Executor) — the `data-native-diagram` placeholder
+
+Native diagrams are resolved at SVG→PPTX conversion time (peer to `<use data-icon>`
+and `<image>`). Executor writes a placeholder rect; the converter splices the
+component in, scaled to the rect.
+
+> Resolver: [`native_diagram_resolver.py`](../scripts/svg_to_pptx/native_diagram_resolver.py).
+
+```xml
+<rect data-native-diagram="<key>"
+      x=".." y=".." width=".." height=".." fill="none"/>
+```
+
+- **`data-native-diagram`** = the chosen `<key>` from `page_diagrams`.
+- **Region sizing by `density`**: `high` → near-full-slide (respect canvas margins);
+  `medium` → ≥ half-slide; `low` → may be a smaller region. The whole figure
+  (including its text) scales to the rect — so do **not** shrink a text-bearing
+  diagram into a tiny region or its labels become illegible. When in doubt, give it
+  the page.
+- The rect itself does not render (it's replaced); keep `fill="none"` (a dashed
+  light stroke is fine as a preview marker). The figure only appears in the PPTX,
+  not in the SVG preview.
+
+---
+
+## 4. Limits
+
+- **Charts not lifted** — entries are diagram/figure structures only; data charts
+  (`graphicFrame`) stay with `templates/charts/`.
+- **No structural surgery** — you cannot add a tier or remove a spoke; the figure is
+  frozen. If the content needs a different slot count, pick a different `key` or use
+  a `charts/` template.
+- **Composed assets** (`type: composite`) are pre-combined figures — use as-is.

--- a/skills/ppt-master/scripts/extract_diagram.py
+++ b/skills/ppt-master/scripts/extract_diagram.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""CLI: extract a slide's diagram into a self-contained native-diagram component.
+
+Usage::
+
+    python3 scripts/extract_diagram.py <source.pptx> <slide_num> \
+        [-o templates/native_diagrams/<key>] [--key <key>] [--summary "..."]
+
+The component renders identically in any deck (theme dependencies flattened) and
+stays natively editable. See ``native_diagrams/extract.py`` for the format.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from native_diagrams import extract_diagram
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Extract a native-diagram component from a .pptx slide.")
+    ap.add_argument("source", help="Source .pptx file")
+    ap.add_argument("slide_num", type=int, help="1-based slide number to lift")
+    ap.add_argument("-o", "--output", help="Component dir (default: ./native_diagram_<slide_num>)")
+    ap.add_argument("--key", help="Library key (default: output dir name)")
+    ap.add_argument("--summary", default="", help="One-line selection summary for the index")
+    args = ap.parse_args()
+
+    out = Path(args.output) if args.output else Path(f"native_diagram_{args.slide_num}")
+    meta = extract_diagram(args.source, args.slide_num, out, key=args.key, summary=args.summary)
+
+    print()
+    print("## Native Diagram Extracted")
+    print()
+    print(f"**Key**: {meta['key']}")
+    print(f"**Source**: {meta['source']} (slide {meta['slide_num']})")
+    print(f"**Path**: {out}")
+    print(f"**Canvas (EMU)**: {meta['canvas_emu'][0]} x {meta['canvas_emu'][1]}")
+    print(f"**Top-level shapes**: {meta['shape_count']}")
+    print(f"**Theme flatten**: {meta['flatten']['colors']} schemeClr -> srgbClr "
+          f"({meta['flatten']['colors_unresolved']} unresolved), "
+          f"{meta['flatten']['fonts']} fonts")
+    print(f"**Media files**: {len(meta['media'])}")
+    if meta["charts_unsupported"]:
+        print(f"**⚠ Charts not lifted (v1)**: {len(meta['charts_unsupported'])} graphicFrame chart(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ppt-master/scripts/inject_diagram.py
+++ b/skills/ppt-master/scripts/inject_diagram.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""CLI: inject a native-diagram component into a deck as native editable shapes.
+
+Usage::
+
+    # drop onto a fresh blank slide in a brand-new deck
+    python3 scripts/inject_diagram.py <component_dir> -o out.pptx
+
+    # append onto an existing deck (new blank slide by default)
+    python3 scripts/inject_diagram.py <component_dir> -o out.pptx --target deck.pptx
+
+    # place into an existing slide, re-framed into a rectangle (EMU)
+    python3 scripts/inject_diagram.py <component_dir> -o out.pptx --target deck.pptx \
+        --slide 2 --into-existing --pos 914400,914400,10363200,5029200
+
+EMU reference: 914400 EMU = 1 inch; a 16:9 slide is 12192000 x 6858000.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from native_diagrams import inject_diagram
+
+
+def _parse_pos(s: str | None):
+    if not s:
+        return None
+    parts = [float(p) for p in s.split(",")]
+    if len(parts) != 4:
+        raise argparse.ArgumentTypeError("--pos must be x,y,w,h in EMU")
+    return tuple(parts)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Inject a native-diagram component into a deck.")
+    ap.add_argument("component", help="Component dir produced by extract_diagram.py")
+    ap.add_argument("-o", "--output", required=True, help="Output .pptx path")
+    ap.add_argument("--target", help="Existing deck to append into (default: new blank deck)")
+    ap.add_argument("--slide", type=int, help="0-based slide index when --into-existing")
+    ap.add_argument("--into-existing", action="store_true",
+                    help="Place into an existing slide instead of adding a new blank one")
+    ap.add_argument("--pos", type=_parse_pos,
+                    help="Reframe into x,y,w,h (EMU); omit to keep original coordinates")
+    args = ap.parse_args()
+
+    result = inject_diagram(
+        args.component,
+        args.output,
+        target_pptx=args.target,
+        slide_index=args.slide,
+        new_slide=not args.into_existing,
+        pos=args.pos,
+    )
+
+    print()
+    print("## Native Diagram Injected")
+    print()
+    print(f"**Output**: {result['out']}")
+    print(f"**Shapes injected**: {result['injected_shapes']}")
+    print(f"**Media re-embedded**: {result['media']}")
+    print(f"**Repositioned**: {result['repositioned']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ppt-master/scripts/make_gallery.py
+++ b/skills/ppt-master/scripts/make_gallery.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Build a browsable HTML gallery of the native-diagram library.
+
+Reads ``diagrams_index.json`` and per-diagram thumbnails (``<previews>/<key>.png``)
+and writes a single ``gallery.html`` you open in any browser: a searchable grid of
+every component with its key, title, slide number, shape count, and media/chart
+badges. Thumbnails are rendered separately (e.g. via PowerPoint export of the
+source slides, which are pixel-faithful to the lifted components).
+
+Usage::
+
+    python3 scripts/make_gallery.py [library_dir] [--previews _previews] [-o gallery.html]
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from pathlib import Path
+
+LIB_DEFAULT = "skills/ppt-master/templates/native_diagrams"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Build an HTML gallery of the native-diagram library.")
+    ap.add_argument("library", nargs="?", default=LIB_DEFAULT)
+    ap.add_argument("--previews", default="_previews", help="thumbnail subdir relative to library")
+    ap.add_argument("-o", "--output", help="output html (default: <library>/gallery.html)")
+    args = ap.parse_args()
+
+    lib = Path(args.library)
+    raw = json.loads((lib / "diagrams_index.json").read_text(encoding="utf-8"))
+    index = raw.get("diagrams", raw)  # tolerate {meta, diagrams} or flat
+    out = Path(args.output) if args.output else lib / "gallery.html"
+    prev = args.previews
+
+    cards = []
+    for key, e in sorted(index.items()):
+        thumb = f"{prev}/{key}.png"
+        img = (
+            f'<img loading="lazy" src="{thumb}">'
+            if (lib / thumb).exists()
+            else '<div class="noimg">no preview</div>'
+        )
+        if e.get("selectable") is False:
+            desc = f'(non-diagram: {e.get("kind","")})'
+            badges = '<span class="b skip">skip</span>'
+            search = e.get("kind", "")
+        else:
+            desc = html.escape(str(e.get("pick", "")))
+            search = f'{e.get("type","")} {e.get("use","")} {e.get("holds","")}'
+            badges = f'<span class="b type">{html.escape(str(e.get("type","")))}</span>'
+            if e.get("density"):
+                badges += f'<span class="b dens">{e["density"]}</span>'
+            if e.get("conf"):
+                badges += f'<span class="b {"hi" if e["conf"]=="high" else "ap"}">{e["conf"]}</span>'
+            if e.get("composed_from"):
+                badges += '<span class="b combo">combo</span>'
+        loc = f'slide {e["slide"]}' if e.get("slide") else "composed"
+        cards.append(
+            f'<div class="card" data-k="{html.escape(key)}" data-t="{html.escape(search)}">{img}'
+            f'<div class="m"><b>{html.escape(key)}</b> · {loc} {badges}<br>'
+            f'<span class="s">{desc}</span></div></div>'
+        )
+
+    doc = f"""<!doctype html><html><head><meta charset="utf-8">
+<title>Native Diagram Library</title><style>
+body{{font-family:system-ui,sans-serif;margin:0;background:#f4f5f7;color:#222}}
+header{{position:sticky;top:0;z-index:9;background:#fff;padding:10px 16px;border-bottom:1px solid #ddd;display:flex;gap:14px;align-items:center}}
+input{{padding:8px;width:300px;border:1px solid #ccc;border-radius:6px;font-size:14px}}
+.grid{{display:grid;grid-template-columns:repeat(auto-fill,minmax(290px,1fr));gap:12px;padding:16px}}
+.card{{background:#fff;border:1px solid #e2e2e2;border-radius:8px;overflow:hidden}}
+.card img{{width:100%;display:block;background:#fafafa}}
+.noimg{{height:160px;display:flex;align-items:center;justify-content:center;color:#bbb}}
+.m{{padding:8px 10px;font-size:13px;line-height:1.45}}
+.s{{margin-top:4px;color:#666;font-size:12px}}
+.b{{display:inline-block;font-size:11px;padding:1px 6px;border-radius:4px;margin-left:5px;color:#5a3d00}}
+.combo{{background:#b2dfdb;color:#004d40}}
+.type{{background:#e3f2fd;color:#0d47a1}}.dens{{background:#f0f0f0;color:#555}}
+.hi{{background:#c8e6c9;color:#1b5e20}}.ap{{background:#fff3cd;color:#7a5b00}}.skip{{background:#eee;color:#999}}
+</style></head><body>
+<header><b>Native Diagram Library</b><span id="c">{len(index)}</span> shown
+<input id="q" placeholder="filter by key / title…" oninput="f()"></header>
+<div class="grid" id="g">{''.join(cards)}</div>
+<script>
+function f(){{var q=document.getElementById('q').value.toLowerCase(),n=0;
+document.querySelectorAll('.card').forEach(function(c){{
+var m=(c.dataset.k+' '+c.dataset.t).toLowerCase().indexOf(q)>=0;
+c.style.display=m?'':'none';if(m)n++}});
+document.getElementById('c').textContent=n}}
+</script></body></html>"""
+    out.write_text(doc, encoding="utf-8")
+    have = sum(1 for k in index if (lib / prev / f"{k}.png").exists())
+    print(f"gallery: {out}")
+    print(f"cards: {len(index)}  thumbnails found: {have}/{len(index)} in {lib / prev}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ppt-master/scripts/native_diagrams/__init__.py
+++ b/skills/ppt-master/scripts/native_diagrams/__init__.py
@@ -1,0 +1,21 @@
+"""Native-diagram library: lift editable DrawingML diagrams between decks.
+
+Unlike the SVG pipeline (``pptx_to_svg`` -> ``svg_to_pptx``), this package never
+re-renders. It lifts a slide's ``<p:sp>`` / ``<p:grpSp>`` XML verbatim and only
+flattens theme dependencies (``schemeClr`` -> ``srgbClr``, theme fonts ->
+typefaces) so the diagram is pixel-identical AND natively editable in any deck.
+
+This module owns the shared component-format primitives (theme flattening). The
+``extract_diagram`` / ``inject_diagram`` tools build on top of them (extract-inject
+tooling layer).
+
+See ``references/native-diagrams.md`` for the placeholder contract consumed by the
+SVG→PPTX converter.
+"""
+from .component import ThemeMaps, flatten_theme, load_theme_maps
+
+__all__ = [
+    "load_theme_maps",
+    "flatten_theme",
+    "ThemeMaps",
+]

--- a/skills/ppt-master/scripts/native_diagrams/__init__.py
+++ b/skills/ppt-master/scripts/native_diagrams/__init__.py
@@ -5,16 +5,20 @@ re-renders. It lifts a slide's ``<p:sp>`` / ``<p:grpSp>`` XML verbatim and only
 flattens theme dependencies (``schemeClr`` -> ``srgbClr``, theme fonts ->
 typefaces) so the diagram is pixel-identical AND natively editable in any deck.
 
-This module owns the shared component-format primitives (theme flattening). The
-``extract_diagram`` / ``inject_diagram`` tools build on top of them (extract-inject
-tooling layer).
+- ``extract_diagram`` — source ``.pptx`` slide -> self-contained component dir
+- ``inject_diagram``  — component dir -> shapes appended into a target deck
+- ``compose``         — combine several components into one new component
 
 See ``references/native-diagrams.md`` for the placeholder contract consumed by the
 SVG→PPTX converter.
 """
 from .component import ThemeMaps, flatten_theme, load_theme_maps
+from .extract import extract_diagram
+from .inject import inject_diagram
 
 __all__ = [
+    "extract_diagram",
+    "inject_diagram",
     "load_theme_maps",
     "flatten_theme",
     "ThemeMaps",

--- a/skills/ppt-master/scripts/native_diagrams/component.py
+++ b/skills/ppt-master/scripts/native_diagrams/component.py
@@ -1,0 +1,235 @@
+"""Shared helpers for the native-diagram library: theme flattening + rel resolution.
+
+A **native diagram** is a self-contained, theme-independent DrawingML shape group
+lifted verbatim out of a source ``.pptx`` slide. Unlike the SVG round-trip
+(``pptx_to_svg`` -> ``svg_to_pptx``), nothing is re-rendered: the original
+``<p:sp>`` / ``<p:grpSp>`` XML is kept byte-for-byte, so decorative flourishes
+(bezier flow arrows, halftone dot patterns, gradient 3D shading) survive intact
+while the shapes stay natively editable in PowerPoint.
+
+The single transform applied is **theme flattening**. Source decks express most
+colors as ``<a:schemeClr>`` (theme references) and fonts as ``+mj-ea`` / ``+mn-lt``
+tokens. Pasted into a deck with a different theme those would recolor / re-font.
+Flattening resolves every ``schemeClr`` -> ``srgbClr`` (through the slide master's
+``clrMap`` and the theme's color scheme) and every theme-font token -> its concrete
+typeface, so the component renders identically in ANY deck.
+
+Modifier children of ``schemeClr`` (``lumMod`` / ``lumOff`` / ``shade`` / ``tint``
+/ ``alpha`` / ``satMod`` …) are preserved untouched — they carry the gradient and
+3D-shading math, and DrawingML accepts them on ``srgbClr`` just as on ``schemeClr``.
+"""
+from __future__ import annotations
+
+import posixpath
+from dataclasses import dataclass
+from lxml import etree
+
+A = "http://schemas.openxmlformats.org/drawingml/2006/main"
+P = "http://schemas.openxmlformats.org/presentationml/2006/main"
+R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+PR = "http://schemas.openxmlformats.org/package/2006/relationships"
+NS = {"a": A, "p": P, "r": R}
+
+# Top-level slide-shape kinds we lift. Everything else under spTree (the group's
+# own nvGrpSpPr / grpSpPr props) is slide scaffolding, not diagram content.
+SHAPE_TAGS = frozenset(
+    {"sp", "grpSp", "pic", "graphicFrame", "cxnSp", "contentPart"}
+)
+
+REL_BASE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/"
+IMAGE_REL = REL_BASE + "image"
+CHART_REL = REL_BASE + "chart"
+LAYOUT_REL = REL_BASE + "slideLayout"
+MASTER_REL = REL_BASE + "slideMaster"
+THEME_REL = REL_BASE + "theme"
+
+
+def local(elem) -> str:
+    """Local tag name without the namespace brace."""
+    return etree.QName(elem).localname
+
+
+# ---------------------------------------------------------------------------
+# Relationship resolution (walk slide -> layout -> master -> theme)
+# ---------------------------------------------------------------------------
+
+def rels_path(part: str) -> str:
+    """``ppt/slides/slide1.xml`` -> ``ppt/slides/_rels/slide1.xml.rels``."""
+    d = posixpath.dirname(part)
+    return posixpath.join(d, "_rels", posixpath.basename(part) + ".rels")
+
+
+def read_rels(zf, part: str) -> list[dict]:
+    """Return the relationship records for *part* (empty list if it has none)."""
+    try:
+        data = zf.read(rels_path(part))
+    except KeyError:
+        return []
+    root = etree.fromstring(data)
+    out = []
+    for rel in root:
+        out.append(
+            {
+                "id": rel.get("Id"),
+                "type": rel.get("Type"),
+                "target": rel.get("Target"),
+                "mode": rel.get("TargetMode"),
+            }
+        )
+    return out
+
+
+def resolve_target(part: str, target: str) -> str:
+    """Resolve a (possibly ``../``-relative) rel target to an absolute zip path."""
+    if target.startswith("/"):
+        return target.lstrip("/")
+    return posixpath.normpath(posixpath.join(posixpath.dirname(part), target))
+
+
+def first_target(zf, part: str, rel_type: str) -> str | None:
+    for rel in read_rels(zf, part):
+        if rel["type"] == rel_type:
+            return resolve_target(part, rel["target"])
+    return None
+
+
+def resolve_master_and_theme(zf, slide_part: str) -> tuple[str, str]:
+    """Walk slide -> layout -> master -> theme. Falls back to ``*1`` parts."""
+    layout = first_target(zf, slide_part, LAYOUT_REL) or "ppt/slideLayouts/slideLayout1.xml"
+    master = first_target(zf, layout, MASTER_REL) or "ppt/slideMasters/slideMaster1.xml"
+    theme = first_target(zf, master, THEME_REL) or "ppt/theme/theme1.xml"
+    return master, theme
+
+
+# ---------------------------------------------------------------------------
+# Theme flattening
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ThemeMaps:
+    colors: dict   # theme slot -> hex  (dk1 / lt1 / dk2 / lt2 / accent1..6 / hlink / folHlink)
+    clrmap: dict   # bg1 / tx1 / bg2 / tx2 / accent1.. -> theme slot (per the slide master)
+    fonts: dict    # +mj-ea / +mn-lt / … -> concrete typeface
+
+    def resolve_color(self, val: str) -> str | None:
+        """``schemeClr`` val -> hex. Honors the (sometimes inverted) clrMap."""
+        if val in self.clrmap:          # bg1 / tx1 / bg2 / tx2 indirect through clrMap
+            return self.colors.get(self.clrmap[val])
+        return self.colors.get(val)     # accent1..6 / dk1 / lt1 … used directly
+
+
+def load_theme_maps(theme_xml: bytes, master_xml: bytes) -> ThemeMaps:
+    theme = etree.fromstring(theme_xml)
+    master = etree.fromstring(master_xml)
+
+    colors: dict[str, str] = {}
+    for c in theme.find(".//a:clrScheme", NS):
+        srgb = c.find("a:srgbClr", NS)
+        sysc = c.find("a:sysClr", NS)
+        if srgb is not None:
+            colors[local(c)] = srgb.get("val")
+        elif sysc is not None:
+            colors[local(c)] = sysc.get("lastClr")
+
+    clrmap_el = master.find("p:clrMap", NS)
+    clrmap = dict(clrmap_el.attrib) if clrmap_el is not None else {}
+
+    fs = theme.find(".//a:fontScheme", NS)
+    mj = fs.find("a:majorFont", NS)
+    mn = fs.find("a:minorFont", NS)
+
+    def typeface(font_el, script: str) -> str | None:
+        e = font_el.find("a:" + script, NS)
+        return e.get("typeface") if (e is not None and e.get("typeface")) else None
+
+    fonts = {
+        "+mj-lt": typeface(mj, "latin"),
+        "+mn-lt": typeface(mn, "latin"),
+        "+mj-ea": typeface(mj, "ea") or typeface(mj, "latin"),
+        "+mn-ea": typeface(mn, "ea") or typeface(mn, "latin"),
+        "+mj-cs": typeface(mj, "cs"),
+        "+mn-cs": typeface(mn, "cs"),
+    }
+    return ThemeMaps(colors=colors, clrmap=clrmap, fonts=fonts)
+
+
+def strip_foreign_rels(sp_tree, keep_rids: set) -> int:
+    """Remove relationship references the component does not carry.
+
+    Lifted shapes routinely point at parts that don't travel with a diagram:
+    ``<p:custDataLst><p:tags r:id>`` (vendor tag parts), hyperlinks, sounds.
+    Left in place, those ``r:id`` / ``r:embed`` values dangle in the target deck
+    and PowerPoint rejects the file as corrupt. *keep_rids* are the media rIds
+    that ``inject`` will remap; everything else is stripped. Returns the count
+    of removed refs/elements.
+    """
+    removed = 0
+    # custDataLst holds <p:tags r:id="..."> pointing at tag parts we don't carry.
+    for cd in list(sp_tree.iter("{%s}custDataLst" % P)):
+        parent = cd.getparent()
+        if parent is not None:
+            parent.remove(cd)
+            removed += 1
+
+    rid_attrs = ("{%s}embed" % R, "{%s}link" % R, "{%s}id" % R)
+    drop_elems = {"hlinkClick", "hlinkHover", "tags", "snd"}
+    for el in list(sp_tree.iter()):
+        for attr in rid_attrs:
+            v = el.get(attr)
+            if v is not None and v not in keep_rids:
+                if local(el) in drop_elems:
+                    parent = el.getparent()
+                    if parent is not None:
+                        parent.remove(el)
+                        removed += 1
+                else:
+                    del el.attrib[attr]
+                    removed += 1
+                break
+    return removed
+
+
+def recolor_shapes(root, color_map: dict) -> int:
+    """Remap explicit ``srgbClr`` hex values in-place (case-insensitive).
+
+    Because the library flattens theme colors to a tiny set of base hexes (the
+    source accents) plus shading modifiers (``lumMod`` / ``shade`` …) that are
+    *kept*, a whole-diagram palette swap is just a base-hex remap: replacing
+    ``558C5A`` -> a new green re-derives every gradient/3D tint from the new base.
+
+    *color_map*: ``{"558C5A": "0E7C7B", ...}`` (``#`` optional, case-insensitive).
+    Returns the number of fills changed.
+    """
+    cmap = {k.upper().lstrip("#"): v.upper().lstrip("#") for k, v in color_map.items()}
+    n = 0
+    for el in root.iter("{%s}srgbClr" % A):
+        v = (el.get("val") or "").upper()
+        if v in cmap:
+            el.set("val", cmap[v])
+            n += 1
+    return n
+
+
+def flatten_theme(sp_tree, maps: ThemeMaps) -> dict:
+    """In-place: ``schemeClr`` -> ``srgbClr`` and theme-font tokens -> typeface.
+
+    Returns a counts dict for reporting / verification.
+    """
+    n_clr = n_skip = 0
+    for sc in list(sp_tree.iter("{%s}schemeClr" % A)):
+        hexv = maps.resolve_color(sc.get("val"))
+        if hexv:
+            sc.tag = "{%s}srgbClr" % A   # children (lumMod/shade/…) are kept verbatim
+            sc.set("val", hexv)
+            n_clr += 1
+        else:
+            n_skip += 1  # e.g. phClr — leave untouched
+
+    n_font = 0
+    for el in sp_tree.iter():
+        tf = el.get("typeface")
+        if tf in maps.fonts and maps.fonts[tf]:
+            el.set("typeface", maps.fonts[tf])
+            n_font += 1
+
+    return {"colors": n_clr, "colors_unresolved": n_skip, "fonts": n_font}

--- a/skills/ppt-master/scripts/native_diagrams/compose.py
+++ b/skills/ppt-master/scripts/native_diagrams/compose.py
@@ -1,0 +1,116 @@
+"""Compose several native-diagram components into one new component.
+
+Each part is loaded, optionally recolored, and wrapped in a group whose ``xfrm``
+maps its source canvas onto a target rectangle (EMU) — so parts can be resized
+and positioned freely. The result is saved as a normal library component
+(``shapes.xml.gz`` + ``meta.json``) and can be injected like any other.
+
+v1 composes pure-vector parts only (no media re-embedding across parts).
+"""
+from __future__ import annotations
+
+import copy
+import gzip
+import itertools
+import json
+from pathlib import Path
+
+from lxml import etree
+
+from .component import A, P, R, recolor_shapes
+
+DEFAULT_CANVAS = (12192000, 6858000)  # 16:9 EMU
+
+
+def _load_diagram_root(comp_dir: Path):
+    gz = comp_dir / "shapes.xml.gz"
+    data = gzip.decompress(gz.read_bytes()) if gz.exists() else (comp_dir / "shapes.xml").read_bytes()
+    return etree.fromstring(data)  # <a:diagram> wrapper
+
+
+def _wrap(shapes, gid: int, src_canvas, pos):
+    cw, ch = src_canvas
+    x, y, w, h = pos
+    grp = etree.Element("{%s}grpSp" % P)
+    nv = etree.SubElement(grp, "{%s}nvGrpSpPr" % P)
+    etree.SubElement(nv, "{%s}cNvPr" % P, id=str(gid), name=f"part{gid}")
+    etree.SubElement(nv, "{%s}cNvGrpSpPr" % P)
+    etree.SubElement(nv, "{%s}nvPr" % P)
+    gpr = etree.SubElement(grp, "{%s}grpSpPr" % P)
+    xf = etree.SubElement(gpr, "{%s}xfrm" % A)
+    etree.SubElement(xf, "{%s}off" % A, x=str(int(x)), y=str(int(y)))
+    etree.SubElement(xf, "{%s}ext" % A, cx=str(int(w)), cy=str(int(h)))
+    etree.SubElement(xf, "{%s}chOff" % A, x="0", y="0")
+    etree.SubElement(xf, "{%s}chExt" % A, cx=str(int(cw)), cy=str(int(ch)))
+    for s in shapes:
+        grp.append(s)
+    return grp
+
+
+def _title_shape(text: str, gid: int, canvas, *, color: str = "222222", size: int = 2800):
+    cw, _ = canvas
+    xml = (
+        f'<p:sp xmlns:a="{A}" xmlns:p="{P}">'
+        f'<p:nvSpPr><p:cNvPr id="{gid}" name="title"/><p:cNvSpPr txBox="1"/><p:nvPr/></p:nvSpPr>'
+        f'<p:spPr><a:xfrm><a:off x="500000" y="240000"/><a:ext cx="{cw - 1000000}" cy="820000"/></a:xfrm>'
+        f'<a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:noFill/></p:spPr>'
+        f'<p:txBody><a:bodyPr/><a:lstStyle/><a:p>'
+        f'<a:r><a:rPr lang="zh-CN" sz="{size}" b="1"><a:solidFill><a:srgbClr val="{color}"/></a:solidFill>'
+        f'<a:latin typeface="微软雅黑"/><a:ea typeface="微软雅黑"/></a:rPr>'
+        f'<a:t>{text}</a:t></a:r></a:p></p:txBody></p:sp>'
+    )
+    return etree.fromstring(xml)
+
+
+def compose_diagram(
+    parts: list[dict],
+    out_dir: str | Path,
+    *,
+    key: str | None = None,
+    title: str = "",
+    title_color: str = "222222",
+    canvas=DEFAULT_CANVAS,
+) -> dict:
+    """Compose parts into a new component.
+
+    Each ``parts`` entry: ``{"dir": <component_dir>, "pos": (x, y, w, h),
+    "recolor": {old: new}?, "src_canvas": (cw, ch)?}``.
+    """
+    out_dir = Path(out_dir)
+    root = etree.Element("{%s}diagram" % A, nsmap={"a": A, "p": P, "r": R})
+    gid = itertools.count(1)
+
+    if title:
+        root.append(_title_shape(title, next(gid), canvas, color=title_color))
+
+    sources = []
+    for part in parts:
+        comp = Path(part["dir"])
+        sources.append(comp.name)
+        diagram = _load_diagram_root(comp)
+        if part.get("recolor"):
+            recolor_shapes(diagram, part["recolor"])
+        shapes = [copy.deepcopy(c) for c in diagram]
+        root.append(_wrap(shapes, next(gid), part.get("src_canvas", canvas), part["pos"]))
+
+    # Unique cNvPr ids across the whole composed slide.
+    for i, cnv in enumerate(root.iter("{%s}cNvPr" % P), start=100):
+        cnv.set("id", str(i))
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    data = etree.tostring(root, xml_declaration=True, encoding="UTF-8")
+    (out_dir / "shapes.xml.gz").write_bytes(gzip.compress(data, mtime=0))
+
+    meta = {
+        "key": key or out_dir.name,
+        "title": title or key or out_dir.name,
+        "composed_from": sources,
+        "canvas_emu": list(canvas),
+        "shape_count": sum(1 for _ in root),
+        "media": {},
+        "charts_unsupported": [],
+    }
+    (out_dir / "meta.json").write_text(
+        json.dumps(meta, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    return meta

--- a/skills/ppt-master/scripts/native_diagrams/extract.py
+++ b/skills/ppt-master/scripts/native_diagrams/extract.py
@@ -1,0 +1,188 @@
+"""Extract one slide's shapes into a self-contained native-diagram component.
+
+Output component layout (``templates/native_diagrams/<key>/``)::
+
+    <key>/
+        shapes.xml     flattened top-level shapes wrapped in <a:diagram>
+        media/         only present when the diagram references bitmaps
+            image1.png
+        meta.json      provenance + media rId map + flatten counts + summary
+
+The component is theme-independent: every ``schemeClr`` has been resolved to
+``srgbClr`` and every theme-font token to a concrete typeface, so it renders
+identically when injected into any deck. Charts (``graphicFrame`` -> chart part)
+are recorded in ``meta['charts_unsupported']`` and NOT lifted — their separate
+chart/embedding parts are out of scope for v1.
+"""
+from __future__ import annotations
+
+import copy
+import gzip
+import html
+import json
+import posixpath
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+from lxml import etree
+
+# Editable text runs, in document order over the serialized shapes. The resolver
+# walks the SAME regex over the SAME stored string, so slot ids align exactly.
+_AT_RE = re.compile(r"<a:t>(.*?)</a:t>", re.DOTALL)
+
+
+def _text_slots(shapes_xml: str) -> list[dict]:
+    """Index every <a:t> run as a fillable text slot, keeping its original text
+    as an authoring hint (what kind of content the slot held in the source)."""
+    return [
+        {"id": i, "text": html.unescape(m.group(1))}
+        for i, m in enumerate(_AT_RE.finditer(shapes_xml))
+    ]
+
+from .component import (
+    A, P, R, NS, SHAPE_TAGS, IMAGE_REL, CHART_REL,
+    local, read_rels, resolve_target, resolve_master_and_theme,
+    load_theme_maps, flatten_theme, strip_foreign_rels,
+)
+
+
+def _representative_title(sp_tree) -> str:
+    """A short title hint for the index: the largest-font text run, else the first.
+
+    These vendor diagrams rarely use real title placeholders, so size is a better
+    signal than document order. Used only as a human-readable summary seed — the
+    curator can overwrite it.
+    """
+    best_sz, best_text, first_text = -1, "", ""
+    for run in sp_tree.iter("{%s}r" % A):
+        t = run.find("{%s}t" % A)
+        if t is None or not (t.text and t.text.strip()):
+            continue
+        txt = " ".join(t.text.split())
+        if not first_text:
+            first_text = txt
+        rpr = run.find("{%s}rPr" % A)
+        sz = int(rpr.get("sz")) if (rpr is not None and (rpr.get("sz") or "").isdigit()) else 0
+        if sz > best_sz:
+            best_sz, best_text = sz, txt
+    return (best_text or first_text)[:40]
+
+
+def extract_diagram(
+    src_pptx: str | Path,
+    slide_num: int,
+    out_dir: str | Path,
+    *,
+    key: str | None = None,
+    summary: str = "",
+) -> dict:
+    src_pptx = Path(src_pptx)
+    out_dir = Path(out_dir)
+    slide_part = f"ppt/slides/slide{slide_num}.xml"
+
+    with zipfile.ZipFile(src_pptx) as z:
+        if slide_part not in z.namelist():
+            raise FileNotFoundError(f"{slide_part} not in {src_pptx.name}")
+
+        slide = etree.fromstring(z.read(slide_part))
+        master_part, theme_part = resolve_master_and_theme(z, slide_part)
+        maps = load_theme_maps(z.read(theme_part), z.read(master_part))
+
+        pres = etree.fromstring(z.read("ppt/presentation.xml"))
+        sz = pres.find("p:sldSz", NS)
+        canvas = [int(sz.get("cx")), int(sz.get("cy"))]
+
+        sp_tree = slide.find(".//p:cSld/p:spTree", NS)
+        title = _representative_title(sp_tree)
+        counts = flatten_theme(sp_tree, maps)
+
+        rels = {r["id"]: r for r in read_rels(z, slide_part)}
+
+        def _chart_rids(el) -> list[str]:
+            """Chart rIds referenced under *el* (a chart uses <c:chart r:id=...>)."""
+            found = []
+            for sub in el.iter():
+                for ak, av in sub.attrib.items():
+                    if ak.endswith("}id") and rels.get(av, {}).get("type") == CHART_REL:
+                        found.append(av)
+            return found
+
+        # Data charts (graphicFrame -> chart part) are NOT lifted: the chart +
+        # embedded-workbook parts live separately (templates/charts/). Drop those
+        # frames from the lifted set and record their rIds — shipping the frame
+        # would leave an empty graphicFrame once strip_foreign_rels drops its r:id.
+        shapes: list = []
+        charts: list[str] = []
+        for c in sp_tree:
+            if local(c) not in SHAPE_TAGS:
+                continue
+            rids = _chart_rids(c)
+            if rids:
+                charts.extend(rids)
+                continue
+            shapes.append(c)
+        if charts:
+            print(
+                f"Note: slide {slide_num}: {len(charts)} chart(s) not lifted "
+                f"(charts stay with templates/charts/): {', '.join(charts)}",
+                file=sys.stderr,
+            )
+
+        # Map embedded-image rIds -> targets among the LIFTED shapes only. Skip
+        # external-linked images (TargetMode=External): their target is a URL, so
+        # resolve_target + z.read would crash on a path that isn't in the package.
+        media_map: dict[str, str] = {}   # rId -> "media/<file>"
+        for s in shapes:
+            for el in s.iter():
+                for k, v in el.attrib.items():
+                    if k.endswith("}embed") or k.endswith("}link"):
+                        rel = rels.get(v)
+                        if rel and rel["type"] == IMAGE_REL and rel.get("mode") != "External":
+                            media_map[v] = rel["target"]
+
+        # Strip non-media rel refs (tags / hyperlinks / sounds / chart leftovers)
+        # so the lifted shapes carry no dangling rIds into the target deck.
+        stripped = strip_foreign_rels(sp_tree, keep_rids=set(media_map))
+
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        # Copy media, dedup by basename, record rId -> local path.
+        media_meta: dict[str, str] = {}
+        if media_map:
+            (out_dir / "media").mkdir(exist_ok=True)
+            for rid, target in media_map.items():
+                abs_path = resolve_target(slide_part, target)
+                fname = posixpath.basename(abs_path)
+                (out_dir / "media" / fname).write_bytes(z.read(abs_path))
+                media_meta[rid] = f"media/{fname}"
+
+        # shapes.xml.gz — a stable <a:diagram> wrapper holding the lifted shapes.
+        # DrawingML is verbose (~1 MB/slide raw) but compresses ~18x, so the
+        # library stays git-friendly. inject reads .gz, falling back to plain .xml.
+        root = etree.Element("{%s}diagram" % A, nsmap={"a": A, "p": P, "r": R})
+        for s in shapes:
+            root.append(copy.deepcopy(s))
+        data = etree.tostring(root, xml_declaration=True, encoding="UTF-8")
+        text_slots = _text_slots(data.decode("utf-8"))
+        (out_dir / "shapes.xml.gz").write_bytes(gzip.compress(data, mtime=0))
+
+    meta = {
+        "key": key or out_dir.name,
+        "title": title,
+        "source": src_pptx.name,
+        "slide_num": slide_num,
+        "canvas_emu": canvas,
+        "shape_count": len(shapes),
+        "media": media_meta,
+        "charts_unsupported": charts,
+        "flatten": counts,
+        "foreign_rels_stripped": stripped,
+        "text_slots": text_slots,
+        "summary": summary,
+    }
+    (out_dir / "meta.json").write_text(
+        json.dumps(meta, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    return meta

--- a/skills/ppt-master/scripts/native_diagrams/inject.py
+++ b/skills/ppt-master/scripts/native_diagrams/inject.py
@@ -1,0 +1,129 @@
+"""Inject a native-diagram component into a target deck as native editable shapes.
+
+The component's flattened shapes are appended into a slide's ``spTree`` verbatim.
+Two pieces of bookkeeping make them collision-free in their new home:
+
+1. **Media** — each referenced bitmap is re-added through python-pptx's
+   ``get_or_add_image_part`` (which registers the content type + relationship),
+   and the shape's ``r:embed`` is rewritten to the freshly issued ``rId``.
+2. **Shape ids** — every ``<p:cNvPr id="...">`` is renumbered above the target
+   slide's current maximum so ids stay unique within the slide.
+
+Optional ``pos=(x, y, w, h)`` (EMU) re-frames the whole diagram by wrapping the
+lifted shapes in a group whose ``a:off`` / ``a:ext`` scales the original canvas
+bounds to the requested rectangle; omit it to drop the diagram at its original
+slide coordinates.
+"""
+from __future__ import annotations
+
+import copy
+import gzip
+import itertools
+import json
+from pathlib import Path
+
+from lxml import etree
+
+from .component import A, P, NS, local
+
+
+def _max_cnvpr_id(sp_tree) -> int:
+    ids = [
+        int(c.get("id"))
+        for c in sp_tree.iter("{%s}cNvPr" % P)
+        if (c.get("id") or "").isdigit()
+    ]
+    return max(ids) if ids else 1
+
+
+def _wrap_in_group(shapes: list, group_id: int, canvas, pos) -> etree._Element:
+    """Wrap *shapes* in a grpSp that maps the canvas bounds onto *pos* (EMU)."""
+    cw, ch = canvas
+    x, y, w, h = pos
+    grp = etree.SubElement(etree.Element("{%s}_tmp" % P), "{%s}grpSp" % P)
+    nv = etree.SubElement(grp, "{%s}nvGrpSpPr" % P)
+    etree.SubElement(nv, "{%s}cNvPr" % P, id=str(group_id), name=f"Diagram {group_id}")
+    etree.SubElement(nv, "{%s}cNvGrpSpPr" % P)
+    etree.SubElement(nv, "{%s}nvPr" % P)
+    gpr = etree.SubElement(grp, "{%s}grpSpPr" % P)
+    xfrm = etree.SubElement(gpr, "{%s}xfrm" % A)
+    etree.SubElement(xfrm, "{%s}off" % A, x=str(int(x)), y=str(int(y)))
+    etree.SubElement(xfrm, "{%s}ext" % A, cx=str(int(w)), cy=str(int(h)))
+    # Child coordinate space stays the original canvas, so the lifted shapes keep
+    # their absolute coords; the off/ext vs chOff/chExt ratio does the scaling.
+    etree.SubElement(xfrm, "{%s}chOff" % A, x="0", y="0")
+    etree.SubElement(xfrm, "{%s}chExt" % A, cx=str(int(cw)), cy=str(int(ch)))
+    for s in shapes:
+        grp.append(s)
+    return grp
+
+
+def inject_diagram(
+    component_dir: str | Path,
+    out_pptx: str | Path,
+    *,
+    target_pptx: str | Path | None = None,
+    slide_index: int | None = None,
+    new_slide: bool = True,
+    pos: tuple[float, float, float, float] | None = None,
+) -> dict:
+    from pptx import Presentation
+
+    comp_dir = Path(component_dir)
+    meta = json.loads((comp_dir / "meta.json").read_text(encoding="utf-8"))
+    gz = comp_dir / "shapes.xml.gz"
+    if gz.exists():
+        root = etree.fromstring(gzip.decompress(gz.read_bytes()))
+    else:  # plain .xml fallback (hand-authored components)
+        root = etree.fromstring((comp_dir / "shapes.xml").read_bytes())
+
+    if target_pptx:
+        prs = Presentation(str(target_pptx))
+    else:
+        prs = Presentation()
+        prs.slide_width, prs.slide_height = meta["canvas_emu"]
+
+    if new_slide or len(prs.slides) == 0:
+        layouts = prs.slide_layouts
+        blank = layouts[6] if len(layouts) > 6 else layouts[-1]  # "Blank" in the default template
+        slide = prs.slides.add_slide(blank)
+    else:
+        idx = slide_index if slide_index is not None else 0
+        slide = prs.slides[idx]
+
+    sp_tree = slide.shapes._spTree
+
+    # Media: re-add each bitmap, build original-rId -> new-rId map.
+    rid_map: dict[str, str] = {}
+    for rid, rel_path in meta.get("media", {}).items():
+        _, new_rid = slide.part.get_or_add_image_part(str(comp_dir / rel_path))
+        rid_map[rid] = new_rid
+
+    shapes = [copy.deepcopy(child) for child in root]
+
+    # Remap embed rIds before id renumbering.
+    if rid_map:
+        for el in shapes:
+            for sub in el.iter():
+                for k, v in list(sub.attrib.items()):
+                    if (k.endswith("}embed") or k.endswith("}link")) and v in rid_map:
+                        sub.set(k, rid_map[v])
+
+    counter = itertools.count(_max_cnvpr_id(sp_tree) + 1)
+    payload = shapes
+    if pos:
+        payload = [_wrap_in_group(shapes, next(counter), meta["canvas_emu"], pos)]
+
+    # Renumber every cNvPr id to stay unique within the slide.
+    for el in payload:
+        for cnv in el.iter("{%s}cNvPr" % P):
+            cnv.set("id", str(next(counter)))
+        sp_tree.append(el)
+
+    prs.save(str(out_pptx))
+    return {
+        "out": str(out_pptx),
+        "injected_shapes": len(shapes),
+        "media": len(rid_map),
+        "repositioned": bool(pos),
+    }

--- a/skills/ppt-master/scripts/scan_pack.py
+++ b/skills/ppt-master/scripts/scan_pack.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Batch-extract every slide of a .pptx into the native-diagram library.
+
+Use this to bulk-import a whole diagram pack ("extract all now, curate later").
+Each slide becomes a ``templates/native_diagrams/<prefix>_<NNN>/`` component and
+gets an entry in ``diagrams_index.json`` whose ``summary`` seeds from the slide's
+largest-font text. The run is resilient: a slide that fails to lift is recorded
+and skipped, never aborting the batch.
+
+Usage::
+
+    python3 scripts/scan_pack.py <source.pptx> \
+        [-o skills/ppt-master/templates/native_diagrams] [--prefix <slug>] [--limit N]
+
+Curate afterwards by deleting unwanted ``<key>/`` dirs and their index entries
+(or re-run ``register`` style by hand). A preview per slide can be rendered
+separately; this tool only does the lift + index.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from native_diagrams import extract_diagram
+
+
+def _slug(text: str) -> str:
+    s = re.sub(r"[^0-9A-Za-z]+", "_", text).strip("_").lower()
+    return s or "deck"
+
+
+def _slide_numbers(zf: zipfile.ZipFile) -> list[int]:
+    nums = []
+    for name in zf.namelist():
+        m = re.match(r"ppt/slides/slide(\d+)\.xml$", name)
+        if m:
+            nums.append(int(m.group(1)))
+    return sorted(nums)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Batch-extract a .pptx into the native-diagram library.")
+    ap.add_argument("source", help="Source .pptx pack")
+    ap.add_argument("-o", "--output", default="skills/ppt-master/templates/native_diagrams",
+                    help="Library root (default: skills/ppt-master/templates/native_diagrams)")
+    ap.add_argument("--prefix", help="Key prefix (default: slug of the .pptx stem)")
+    ap.add_argument("--limit", type=int, help="Only the first N slides (debug)")
+    args = ap.parse_args()
+
+    src = Path(args.source)
+    out_root = Path(args.output)
+    out_root.mkdir(parents=True, exist_ok=True)
+    prefix = args.prefix or _slug(src.stem)
+
+    with zipfile.ZipFile(src) as zf:
+        slide_nums = _slide_numbers(zf)
+    if args.limit:
+        slide_nums = slide_nums[: args.limit]
+
+    index_path = out_root / "diagrams_index.json"
+    raw = json.loads(index_path.read_text(encoding="utf-8")) if index_path.exists() else {}
+    # Read/write the new {meta, diagrams} shape; tolerate (and upgrade) a legacy
+    # flat index. Writing flat here would corrupt a curated {meta, diagrams} file.
+    meta_block = raw.get("meta") if isinstance(raw, dict) else None
+    index = raw.get("diagrams", raw) if isinstance(raw, dict) else {}
+
+    ok = fail = with_media = with_charts = 0
+    failures: list[tuple[int, str]] = []
+    for n in slide_nums:
+        key = f"{prefix}_{n:03d}"
+        try:
+            meta = extract_diagram(src, n, out_root / key, key=key)
+        except Exception as exc:  # keep the batch going
+            fail += 1
+            failures.append((n, f"{type(exc).__name__}: {exc}"))
+            continue
+        index[key] = {
+            "summary": meta.get("title") or f"(slide {n})",
+            "source": meta["source"],
+            "slide": n,
+            "shapes": meta["shape_count"],
+            "media": len(meta["media"]),
+            "charts": len(meta["charts_unsupported"]),
+        }
+        ok += 1
+        with_media += bool(meta["media"])
+        with_charts += bool(meta["charts_unsupported"])
+
+    index = {k: index[k] for k in sorted(index)}
+    out: dict = {}
+    if meta_block is not None:
+        out["meta"] = meta_block
+    out["diagrams"] = index
+    index_path.write_text(json.dumps(out, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    print()
+    print("## Pack Scan Complete")
+    print()
+    print(f"**Source**: {src.name}  ({len(slide_nums)} slides)")
+    print(f"**Extracted**: {ok}   **Failed**: {fail}")
+    print(f"**With media**: {with_media}   **With charts (partial lift)**: {with_charts}")
+    print(f"**Library**: {out_root}  ({len(index)} total entries)")
+    if failures:
+        print()
+        print("### Failures")
+        for n, msg in failures[:30]:
+            print(f"- slide {n}: {msg}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ppt-master/scripts/svg_to_pptx/drawingml_converter.py
+++ b/skills/ppt-master/scripts/svg_to_pptx/drawingml_converter.py
@@ -363,6 +363,27 @@ def convert_element(elem: ET.Element, ctx: ConvertContext) -> ShapeResult | None
         event.update(metadata)
         ctx.trace_events.append(event)
 
+    # Native-diagram placeholder: an element (typically <rect>) carrying
+    # data-native-diagram is resolved by splicing the named component's
+    # DrawingML in, scaled to the placeholder rect — peer to <use data-icon>
+    # and <image>. Intercept before the normal tag dispatch so the placeholder
+    # rect never reaches convert_rect.
+    if elem.get('data-native-diagram'):
+        from .native_diagram_resolver import resolve_native_diagram
+        try:
+            result = resolve_native_diagram(elem, ctx)
+        except SvgNativeConversionError:
+            trace('error', error='native-diagram resolve failed')
+            raise  # already a precise native-diagram error; don't double-wrap
+        except Exception as e:
+            trace('error', error=str(e))
+            raise SvgNativeConversionError(
+                f"Failed to resolve data-native-diagram="
+                f"{elem.get('data-native-diagram')!r}: {e}"
+            ) from e
+        trace('native-diagram', key=elem.get('data-native-diagram'))
+        return result
+
     converter = _CONVERTERS.get(tag)
     if converter:
         try:

--- a/skills/ppt-master/scripts/svg_to_pptx/native_diagram_resolver.py
+++ b/skills/ppt-master/scripts/svg_to_pptx/native_diagram_resolver.py
@@ -1,0 +1,135 @@
+"""Resolve ``data-native-diagram`` placeholders into spliced DrawingML.
+
+This makes native-diagram components a first-class peer of ``<use data-icon>``
+and ``<image>`` in the SVG -> DrawingML pipeline. The Executor draws a placeholder
+rect in the SVG::
+
+    <rect data-native-diagram="combo_product_system"
+          x="140" y="120" width="1000" height="480" fill="none"/>
+
+and at conversion time the named component's shapes (already DrawingML) are
+spliced in, scaled to the placeholder rect.
+
+Splicing is string-based (not ElementTree) so the component's namespace prefixes
+(``a`` / ``p`` / ``r`` / ``a14`` / ``a16`` / …) stay byte-exact: the stored
+``<a:diagram ...>`` wrapper — which carries every ``xmlns`` declaration — is
+rewritten into a ``<p:grpSp ...>`` wrapper, keeping those declarations intact.
+
+This module owns the core splice path (scale + media-remap + id-renumber). The
+recolor / text-substitution / font-normalisation transforms layer on top via the
+``data-recolor`` / ``data-text`` / ``data-font`` attributes.
+
+See ``references/native-diagrams.md`` for the placeholder attribute contract.
+"""
+from __future__ import annotations
+
+import gzip
+import json
+import re
+import sys
+from pathlib import Path
+
+from .drawingml_context import ConvertContext, ShapeResult
+from .drawingml_utils import ctx_x, ctx_y, ctx_w, ctx_h, px_to_emu
+
+LIB_DIR = Path(__file__).resolve().parent.parent.parent / "templates" / "native_diagrams"
+IMAGE_REL = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"
+
+
+def _f(v) -> float:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _renumber_cnvpr(xml: str, ctx: ConvertContext) -> str:
+    """Reassign every ``<p:cNvPr id>`` from the slide's id allocator (unique)."""
+    return re.sub(
+        r'(<p:cNvPr id=")\d+(")',
+        lambda m: f"{m.group(1)}{ctx.next_id()}{m.group(2)}",
+        xml,
+    )
+
+
+def _remap_media(xml: str, comp_dir: Path, media_map: dict, ctx: ConvertContext) -> str:
+    """Register each referenced bitmap on the slide and remap its ``r:embed``."""
+    for old_rid, rel_path in media_map.items():
+        fpath = comp_dir / rel_path
+        if not fpath.exists():
+            continue
+        ext = fpath.suffix.lstrip(".").lower()
+        if ext == "jpeg":
+            ext = "jpg"
+        fname = f"s{ctx.slide_num}_nd{len(ctx.media_files) + 1}.{ext}"
+        ctx.media_files[fname] = fpath.read_bytes()
+        new_rid = ctx.next_rel_id()
+        ctx.rel_entries.append(
+            {"id": new_rid, "type": IMAGE_REL, "target": f"../media/{fname}"}
+        )
+        xml = re.sub(r'(r:(?:embed|link)=")' + re.escape(old_rid) + r'(")',
+                     r"\g<1>" + new_rid + r"\g<2>", xml)
+    return xml
+
+
+def resolve_native_diagram(elem, ctx: ConvertContext) -> ShapeResult | None:
+    """Splice the referenced component, scaled into the placeholder rect."""
+    from .drawingml_converter import SvgNativeConversionError
+
+    key = elem.get("data-native-diagram")
+    comp_dir = LIB_DIR / key
+    # A key is authored, not user input — but a malformed value that escapes the
+    # library directory must fail loudly, never read an arbitrary file.
+    if not comp_dir.resolve().is_relative_to(LIB_DIR.resolve()):
+        raise SvgNativeConversionError(
+            f"data-native-diagram key escapes the library: {key!r} "
+            f"(use a bare component name)"
+        )
+    gz, plain = comp_dir / "shapes.xml.gz", comp_dir / "shapes.xml"
+    if gz.exists():
+        xml = gzip.decompress(gz.read_bytes()).decode("utf-8")
+    elif plain.exists():
+        xml = plain.read_text(encoding="utf-8")
+    else:
+        raise SvgNativeConversionError(f"data-native-diagram: component not found: {key}")
+    meta = json.loads((comp_dir / "meta.json").read_text(encoding="utf-8"))
+
+    # Placeholder geometry -> EMU target rect (honours the context transform).
+    x = ctx_x(_f(elem.get("x")), ctx)
+    y = ctx_y(_f(elem.get("y")), ctx)
+    w = ctx_w(_f(elem.get("width")), ctx)
+    h = ctx_h(_f(elem.get("height")), ctx)
+    if w <= 0 or h <= 0:
+        print(
+            f"Warning: data-native-diagram={key!r} skipped — zero placeholder size "
+            f"(w={w}, h={h}); check the rect's width/height.",
+            file=sys.stderr,
+        )
+        return None
+    off_x, off_y = px_to_emu(x), px_to_emu(y)
+    ext_cx, ext_cy = px_to_emu(w), px_to_emu(h)
+    ch_cx, ch_cy = meta["canvas_emu"]
+
+    xml = re.sub(r"^\s*<\?xml[^>]*\?>\s*", "", xml, count=1)
+    if meta.get("media"):
+        xml = _remap_media(xml, comp_dir, meta["media"], ctx)
+    xml = _renumber_cnvpr(xml, ctx)
+
+    # Rewrite <a:diagram ...> -> <p:grpSp ...> (keep its xmlns decls) + group props.
+    m = re.match(r"<a:diagram\b([^>]*)>", xml)
+    if not m:
+        raise SvgNativeConversionError(f"data-native-diagram: malformed component {key}")
+    ns_attrs = m.group(1)
+    gid = ctx.next_id()
+    props = (
+        f'<p:nvGrpSpPr><p:cNvPr id="{gid}" name="NativeDiagram {gid}"/>'
+        f"<p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>"
+        f'<p:grpSpPr><a:xfrm><a:off x="{off_x}" y="{off_y}"/>'
+        f'<a:ext cx="{ext_cx}" cy="{ext_cy}"/>'
+        f'<a:chOff x="0" y="0"/><a:chExt cx="{ch_cx}" cy="{ch_cy}"/></a:xfrm></p:grpSpPr>'
+    )
+    body = xml[m.end():].replace("</a:diagram>", "</p:grpSp>")
+    return ShapeResult(
+        xml=f"<p:grpSp{ns_attrs}>{props}{body}",
+        bounds_emu=(off_x, off_y, off_x + ext_cx, off_y + ext_cy),
+    )


### PR DESCRIPTION
Library-scale tooling on the engine: batch-extract a whole .pptx into the
component library and render an HTML gallery.

What's in this PR
- scan_pack.py: batch-lift every slide of a source deck into the library and
  seed/update diagrams_index.json.
- make_gallery.py: render the index + per-component thumbnails to gallery.html.

Blocker fixed (your item 3)
scan_pack.py read the index raw and wrote it back FLAT ({key: ...}), which
corrupts a curated { meta, diagrams } index (the new format that
build_diagram_index.py and make_gallery.py already use). It now reads
raw.get("diagrams", raw), preserves meta, writes the { meta, diagrams } shape,
and upgrades a legacy flat file in place.

Scope: stacked on feat/native-diagram-engine (scan_pack imports
extract_diagram). The scan/gallery half of your tooling bucket.
Verified: py_compile + a synthetic round-trip test (preserves meta; upgrades
legacy flat; never writes flat).

---
Stacked on #159 -- please review/merge after it (cross-fork base is `main`, so the diff is cumulative until the parent merges).

---
**6-PR split -- review / merge order** (cross-fork base is `main`, so a child PR's diff is cumulative until its parent merges, then auto-cleans):
1. #156 core
2. #158 text-font (<- #156)  |  #159 engine (<- #156)
3. #160 workflow (<- #158)  |  #161 catalog (<- #159)
4. #157 self-evolution (independent, any time)

The native-diagram asset library is held pending a licensing pass and is not yet opened.