### PR TITLE
fix(shared-standards): 统一 resting flood-opacity 上界为 0.10，并将 tag-not-found 静默回落改为单次汇总警告

### DIFF
--- a/skills/ppt-master/references/executor-base.md
+++ b/skills/ppt-master/references/executor-base.md
@@ -123,7 +123,7 @@ Before drawing each page, look up its entry in `page_rhythm` (key format `P<NN>`
 
 **Missing `page_rhythm` section** → emit `warning: spec_lock.md missing page_rhythm — defaulting all pages to dense` once, fall back to `dense` for all pages.
 
-**Tag not found for current page** → fall back to `dense` silently. Do not invent a tag.
+**Tag not found for current page** → emit `warning: spec_lock.md page_rhythm tag not found for P<NN> — falling back to dense` once per deck (aggregate; do not repeat per page), fall back to `dense`. Do not invent a tag.
 
 **Per-page template lookup — `page_layouts` section**:
 

--- a/skills/ppt-master/references/shared-standards.md
+++ b/skills/ppt-master/references/shared-standards.md
@@ -380,7 +380,7 @@ All `feOffset` on a page must share the same `dx`/`dy` direction. Default: `dx="
 #### Restraint over visibility
 
 Standard: "the shadow is felt, not seen." If noticed, it's too strong.
-- Resting cards: `flood-opacity` 0.06-0.12
+- Resting cards: `flood-opacity` 0.06-0.10
 - Raised elements (CTA, overlay): max `flood-opacity` 0.20
 - Above 0.20 = Office 2007 hard-shadow look
 - Color: near-black at low opacity, or a darker tint of background. Brand-color shadow only on accent elements sharing that hue.
@@ -424,7 +424,7 @@ Best for: cards, floating panels, elevated elements. The `svg_to_pptx` converter
 Recommended parameters (see "Two-tier elevation maximum" above for tier guidance):
 ```
 stdDeviation:   4–16       (resting cards: 4–8;  raised elements: 10–16)
-flood-opacity:  0.06–0.12  (resting cards — default)
+flood-opacity:  0.06–0.10  (resting cards — default)
                 0.12–0.20  (raised elements only — primary CTA, overlay)
                 NEVER     > 0.20  (Office 2007 hard-shadow look)
 dy:             2–10       (resting: 2–4;  raised: 6–10)


### PR DESCRIPTION
## 改了什么

1. `shared-standards.md` §6 散文（:383）和 Recommended 块（:427）的 resting cards `flood-opacity` 上界由 `0.12` 改为 `0.10`，与同节表格（:395，已是 `0.06-0.10`）和代码示例（:413，已是 `0.10`）对齐。
2. `executor-base.md` §2.1 `page_rhythm` Tag not found（:126）将「fall back to `dense` silently」改为出声但不阻塞，整 deck 只汇总一条，与 :99（spec_lock missing）、:124（missing page_rhythm）的 warning 风格一致。

## 为什么

- 四处本应描述同一约束（resting 上界）。表格/代码已是 0.10，散文/Recommended 写 0.12，模型读到矛盾会偏向取高值，使 resting shadow 比设计意图重。统一到 0.10 消除歧义（单一真值）。
- 静默回落无法被 reviewer / QA 发现，与同文件其他 fallback 不一致。改单次 warning 不影响执行，但让生成日志可追溯。

对应 #163 讨论中达成一致的两条（一致性 / 可靠性）。纯文档 / 规则修复，不改代码逻辑。