### PR TITLE
docs(executor+design-spec+strategist): CJK 行高下限对齐 CLReq + hero 信号化（单焦点页豁免说明）

### DIFF
--- a/skills/ppt-master/references/executor-base.md
+++ b/skills/ppt-master/references/executor-base.md
@@ -91,7 +91,7 @@ Before the first SVG page, output a confirmation listing: canvas dimensions, bod
 
 **Per-block expression**: render each `design_spec.md §IX Content` block in its written texture — a full-sentence block as wrapped prose, a fragment/label block as bullets/keywords. **Never split a full-sentence block into a bullet list** — not because a bullet lays out easier, and not because an inherited template slot is shaped as a list. If a block carries no clear texture, infer the mode from its wording and the page layout.
 
-- **Prose render recipe**: one `<text>` per paragraph; wrap lines with sibling `<tspan>` that reset `x` to the block's left edge and advance `dy` ≈ 1.4× the font size. Fit about width ÷ font-size CJK glyphs per line (Latin fits roughly twice that); the last line runs short. Use the body ramp size, not a new one.
+- **Prose render recipe**: one `<text>` per paragraph; wrap lines with sibling `<tspan>` that reset `x` to the block's left edge and advance `dy` by the font size × a line-height factor: ~1.4–1.5× for dense/small-body blocks (per CLReq comfortable minimum); 1.6–2.0× for large-type, sparse, or `breathing` page blocks. Fit about width ÷ font-size CJK glyphs per line (Latin fits roughly twice that); the last line runs short. Use the body ramp size, not a new one.
 - **Template precedence**: when an inherited template slot is a bullet list but the §IX block is prose, the prose wins — widen or reflow the container to hold the paragraph, or drop that card; do not pour the sentence back into the list slot.
 
 > Note: block-level phrasing, applied *within* the page's `page_rhythm` density (below), not against it.

--- a/skills/ppt-master/references/strategist.md
+++ b/skills/ppt-master/references/strategist.md
@@ -226,6 +226,8 @@ Baseline choice follows **content density**, not style. Common: `18px` (dense) /
 
 > Two baseline columns are illustrative only — for any other baseline (16/20/22/28/32…), multiply the row's ratio. Checker reads live `body` from `spec_lock.md`. Executor may pick any px within a role's band without pre-declaring; values outside **every** band require lock extension first.
 
+> **Hero in single-focus / breathing pages**: when one element *is* the entire page — a large number, a headline, a key phrase — it is the visual subject, not body content. Such heroes may borrow the cover-title band (2.5–5×); for greater emphasis, declare a hero slot in `spec_lock.md` (e.g., `hero_number` / `hero_headline`) — checker exempts declared slots with no fixed upper limit. The row above "Hero number (consulting KPIs) 1.5–2×" applies only to numeric KPIs in dashboard/data layouts, not to full-page focal elements.
+
 #### Formula Rendering Policy
 
 Formula rendering is part of Typography confirmation. Recommend one policy and let the user confirm or override it inside item g.

--- a/skills/ppt-master/templates/design_spec_reference.md
+++ b/skills/ppt-master/templates/design_spec_reference.md
@@ -145,6 +145,8 @@ Two views on the same font decisions — fill both, keep them consistent:
 
 > Sizes outside **every** band remain forbidden — surface the need and extend `spec_lock.md typography` (e.g., `cover_title: 96`) rather than invent a one-off value.
 
+> **Hero in single-focus / breathing pages**: when one element *is* the entire page — a large number, a headline, a key phrase — it is the visual subject, not body content. Such heroes may borrow the cover-title band (2.5–5×); for greater emphasis, declare a hero slot in `spec_lock.md` (e.g., `hero_number` / `hero_headline`) — checker exempts declared slots with no fixed upper limit. The row above "Hero number (consulting KPIs) 1.5–2×" applies only to numeric KPIs in dashboard/data layouts, not to full-page focal elements.
+
 ---
 
 ## V. Layout Principles
@@ -199,7 +201,7 @@ Two views on the same font decisions — fill both, keep them consistent:
 **Non-card containers** (naked text blocks / full-bleed imagery / divider-separated content — typical for `breathing` pages or minimalist designs):
 
 - Vertical rhythm carried by **whitespace**, not gutters — block gaps run wider than card gaps since there's no container edge to separate content.
-- **Line-height**: 1.4-1.6× body font size.
+- **Line-height**: ~1.4–1.5× for dense/small-body text (CLReq comfortable minimum); 1.6–2.0× for large-type, sparse, or `breathing` pages.
 - **Full-bleed text placement**: inset text away from the image's focal points; legibility over photographic backgrounds typically needs a gradient or opacity overlay.
 - **Content width** is driven by reading comfort and image composition, not a card grid slot — don't back-compute "column width" when there's no column.
 


### PR DESCRIPTION
承接 #163 讨论中达成一致的两条排版/ramp 改进。均为描述性引导，不改代码、不动 checker。

## 改了什么

1. **CJK 行高（`executor-base.md:94` + `design_spec_reference.md:202`）**：把固定 `dy ≈ 1.4×` / `1.4-1.6×` 改为密度分档引导句——下限对齐 CLReq 舒适带（~1.5×），大字 / 稀疏 / `breathing` 页放松到 1.6–2.0×；密集 / 小字块仍可 ~1.4–1.5×。写成引导，不做硬桶。

2. **Hero 信号化（`design_spec_reference.md` 与 `strategist.md` 同一张 ramp 表，两处同步）**：保留 `Hero number (consulting KPIs) 1.5-2×` 行（对密集 KPI 仪表盘正确），在表下补一段说明——单焦点 / `breathing` 页里「一个元素就是整页」的 hero（大数字 / 大标题 / 关键短语）是画面主体，可借 cover-title 的 2.5–5× 档；更突出可在 `spec_lock.md` 声明 hero slot（如 `hero_number`），checker 对声明过的 slot 豁免。

## 为什么

- 行高：现状对密集小字合理，但作为唯一写法会让 breathing / 大字块偏挤；CLReq 指向 CJK 正文行高 ≥1.5×。分档引导既保留密集场景，又给稀疏场景正确上界。
- Hero：原 `1.5-2×` 仅描述 KPI 仪表盘场景；模型遇到「整页一个大数字」会误套此上界，丢了视觉主导感。补说明后模型知道单焦点 hero 可进 2.5–5× 档。**机制已存在**（`hero_number` slot 已记录、超界仅 warning），本 PR 只是在 ramp 处点明，不需改 checker。