### PR TITLE
feat(template-fill): check-plan 增加两条规划护栏（含非文字源页风险 + 同源页过度复用）

### DIFF
--- a/skills/ppt-master/scripts/template_fill_pptx/analyzer.py
+++ b/skills/ppt-master/scripts/template_fill_pptx/analyzer.py
@@ -143,6 +143,29 @@ def _canvas_px(pres_root: ET.Element) -> dict[str, int | None]:
     }
 
 
+def _fill_risk(tables: list[dict[str, Any]], charts: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return a fill_risk descriptor when the slide has non-text content that text-fill cannot replace.
+
+    Only tables and charts are checked; no new dependencies are introduced.
+    Returns None when the slide has no such content.
+    """
+    kinds: list[str] = []
+    if tables:
+        kinds.append("table")
+    if charts:
+        kinds.append("chart")
+    if not kinds:
+        return None
+    kind_str = "/".join(kinds)
+    return {
+        "has_non_text_content": True,
+        "reason": (
+            f"含 {kind_str} 等非文字内容,text-fill 不替换,"
+            "需 table_edits/chart_edits 或换页"
+        ),
+    }
+
+
 def analyze_pptx(pptx_path: Path) -> dict[str, Any]:
     """Extract a slide library with text replacement slots."""
     with zipfile.ZipFile(pptx_path) as zf:
@@ -180,16 +203,18 @@ def analyze_pptx(pptx_path: Path) -> dict[str, Any]:
             tables = _analyze_tables(slide_root, slide_ref.index)
             charts = _analyze_charts(zf, slide_root, slide_ref)
             slide_text = "\n".join(slot["text"] for slot in slots if slot["text"])
-            slides.append(
-                {
-                    "slide_index": slide_ref.index,
-                    "page_type": _classify_page_type(slide_ref.index, len(slide_refs), slide_text, slots),
-                    "text_summary": slide_text[:500],
-                    "slots": slots,
-                    "tables": tables,
-                    "charts": charts,
-                }
-            )
+            slide: dict[str, Any] = {
+                "slide_index": slide_ref.index,
+                "page_type": _classify_page_type(slide_ref.index, len(slide_refs), slide_text, slots),
+                "text_summary": slide_text[:500],
+                "slots": slots,
+                "tables": tables,
+                "charts": charts,
+            }
+            risk = _fill_risk(tables, charts)
+            if risk is not None:
+                slide["fill_risk"] = risk
+            slides.append(slide)
 
     return {
         "schema": "template_fill_pptx_library.v1",

--- a/skills/ppt-master/scripts/template_fill_pptx/checker.py
+++ b/skills/ppt-master/scripts/template_fill_pptx/checker.py
@@ -203,6 +203,11 @@ def _capacity_for_report(
     return _display_width(max(capacity, old_width))
 
 
+def _library_slide_index(library: dict[str, Any]) -> dict[int, dict[str, Any]]:
+    """Build a mapping from slide_index to slide dict for O(1) lookup."""
+    return {int(s.get("slide_index", 0)): s for s in library.get("slides", [])}
+
+
 def check_plan(library: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
     """Compare fill replacements against source slot capacity."""
     lookup = _slot_lookup(library)
@@ -427,6 +432,84 @@ def check_plan(library: dict[str, Any], plan: dict[str, Any]) -> dict[str, Any]:
                     "message": "chart edit target and data shape are valid",
                 }
             )
+    # --- Guardrail 2: source slides with non-text content not covered by edits ---
+    # For each plan slide, if the source slide has tables/charts in the library
+    # but the plan slide provides no matching table_edits/chart_edits, warn that
+    # text-fill will silently leave the original template content in place.
+    lib_slides = _library_slide_index(library)
+    for plan_slide_index, slide in enumerate(plan.get("slides", []), start=1):
+        source_slide = int(slide.get("source_slide", 0))
+        lib_slide = lib_slides.get(source_slide)
+        if lib_slide is None:
+            continue
+        lib_tables = lib_slide.get("tables", [])
+        lib_charts = lib_slide.get("charts", [])
+        if not lib_tables and not lib_charts:
+            continue
+        # Check whether the plan slide provides edits covering the non-text content.
+        has_table_edits = bool(slide.get("table_edits"))
+        has_chart_edits = bool(slide.get("chart_edits"))
+        uncovered_kinds: list[str] = []
+        if lib_tables and not has_table_edits:
+            uncovered_kinds.append("table")
+        if lib_charts and not has_chart_edits:
+            uncovered_kinds.append("chart")
+        if not uncovered_kinds:
+            continue
+        kind_str = "/".join(uncovered_kinds)
+        summary["warn"] += 1
+        results.append(
+            {
+                "status": "WARN",
+                "plan_slide": plan_slide_index,
+                "source_slide": source_slide,
+                "message": (
+                    f"源页 {source_slide} 含 {kind_str} 等非文字内容,"
+                    "plan 未提供对应 edits,text-fill 不会替换,"
+                    "可能漏出模板原文(加 table_edits/chart_edits,或换一个源页)"
+                ),
+            }
+        )
+
+    # --- Guardrail 1: same source slide reused too many times while unused layouts exist ---
+    # Use a relative condition rather than an absolute threshold: only warn when
+    # (a) a source slide is reused >= REUSE_WARN_THRESHOLD times, AND
+    # (b) there are library slides that the plan never uses at all.
+    # Rationale: a small template where every layout is referenced is fine even at
+    # high per-slide reuse; "15-page template where only 1 page is ever cloned and
+    # the rest sit idle" is the real smell we want to surface.
+    # Threshold of 3: any source appearing 3+ times in a plan is meaningful reuse
+    # (cover / TOC / ending typically appear at most twice), so >= 3 is a practical
+    # signal without being overly sensitive.
+    REUSE_WARN_THRESHOLD = 3
+    source_use_counts: dict[int, int] = {}
+    for slide in plan.get("slides", []):
+        src = int(slide.get("source_slide", 0))
+        if src:
+            source_use_counts[src] = source_use_counts.get(src, 0) + 1
+    all_lib_indices = {int(s.get("slide_index", 0)) for s in library.get("slides", []) if s.get("slide_index")}
+    used_lib_indices = set(source_use_counts.keys())
+    unused_lib_indices = sorted(all_lib_indices - used_lib_indices)
+    if unused_lib_indices:
+        for src, count in sorted(source_use_counts.items()):
+            if count >= REUSE_WARN_THRESHOLD:
+                unused_list = ", ".join(str(i) for i in unused_lib_indices)
+                summary["warn"] += 1
+                results.append(
+                    {
+                        "status": "WARN",
+                        "source_slide": src,
+                        "reuse_count": count,
+                        "unused_source_slides": unused_lib_indices,
+                        "message": (
+                            f"源页 {src} 被复用 {count} 次,"
+                            f"而库里还有 {len(unused_lib_indices)} 个源版式没用到"
+                            f"(索引:{unused_list});"
+                            "考虑用上其它版式以增加变化"
+                        ),
+                    }
+                )
+
     return {"schema": "template_fill_pptx_check.v1", "summary": summary, "results": results}
 
 
@@ -441,10 +524,13 @@ def print_check_report(report: dict[str, Any]) -> None:
                 "{status} P{plan_slide:02d} source={source_slide} {slot_id} "
                 "{role} old={old_len} new={new_len} ratio={ratio}: {message}".format(**item)
             )
-        else:
+        elif "plan_slide" in item:
             target = item.get("slot_id") or item.get("selector") or ""
             line = (
                 f"{item['status']} P{item['plan_slide']:02d} "
                 f"source={item['source_slide']} {target}: {item['message']}".strip()
             )
+        else:
+            # Guardrail 1 WARNs are source-level (no plan_slide); print source + message.
+            line = f"{item['status']} source={item.get('source_slide', '?')}: {item['message']}"
         print(line)


### PR DESCRIPTION
承接 #174 你敲定的 scope，维持轻量（零新依赖、零额外 token，不动 scope / 生成自由度）。

## 改了什么
- **`analyzer.py`**：含 `tables`/`charts` 的源页加 `fill_risk` 标记（一句原因：非文字内容 text-fill 不替换，需 `table_edits`/`chart_edits` 或换页）。纯用现成检测，零新依赖。
- **`checker.py` 护栏 2**（你说先做的）：plan 选中的源页有 table/chart 但没提供对应 `table_edits`/`chart_edits` → WARN「可能漏出模板原文」。确定性、和模板大小无关。
- **`checker.py` 护栏 1**（按你的「相对条件」）：某源页复用 **≥3 次** **且** 库里还有从未被用到的源版式 → WARN（列出未用索引）。绝对计数会假阳（小模板全用上合理），相对条件只在「反复薅 1 页、其它空着」时才报。

测试（用一个真实 demo 项目）：护栏 1 正确触发 2 条（某源页复用 5 次、另一源页复用 3 次，库里多个版式闲置）；护栏 2 在该 demo 不触发——原因见下。

## 一个诚实的更正（关于护栏 2）
实测时我发现：**我在 #174 里把那个「漏出模板原文」的页说成「嵌入表格」，其实不准。** 那个模板根本没有任何 native table/chart；真实情况是——那张源页有 **76 个文字槽**，plan 只填了一小撮，**其余几十个槽保留了模板原文**。所以：
- 护栏 2（table/chart）**对「有原生表/图的模板」仍有效**，我按你的 scope 实现了；
- 但它**堵不住这种「文字槽没填满」导致的漏原文**。

**真正能堵这类的是另一条：「低槽位覆盖率」warn** —— 源页槽位很多、但 plan 只覆盖一小撮（填的槽数 ÷ 源页总槽数 低于某比例）→ WARN「大量槽位将保留模板原文」。同样轻量、确定性、零依赖。

**这条我没擅自加（你没批过）。要不要也加上？** 它才是堵我那个 demo 漏原文的对的工具。你定，我再补一个 commit 或单开。

按 `docs/rules`。