### PR TITLE
Fix template image fallback in PPTX export

### DIFF
--- a/skills/ppt-master/scripts/svg_to_pptx/drawingml_elements.py
+++ b/skills/ppt-master/scripts/svg_to_pptx/drawingml_elements.py
@@ -1690,6 +1690,8 @@ def convert_image(elem: ET.Element, ctx: ConvertContext) -> ShapeResult | None:
         if not img_path.exists():
             img_path = ctx.svg_dir.parent / href
         if not img_path.exists():
+            img_path = ctx.svg_dir.parent / 'templates' / href
+        if not img_path.exists():
             raise FileNotFoundError(f'External image not found: {href}')
         img_format = img_path.suffix.lstrip('.').lower()
         if img_format == 'jpeg':
@@ -1890,6 +1892,8 @@ def convert_nested_svg(elem: ET.Element, ctx: ConvertContext) -> ShapeResult | N
         img_path = ctx.svg_dir / href
         if not img_path.exists():
             img_path = ctx.svg_dir.parent / href
+        if not img_path.exists():
+            img_path = ctx.svg_dir.parent / 'templates' / href
         if not img_path.exists():
             raise FileNotFoundError(f'External image not found: {href}')
         img_format = img_path.suffix.lstrip('.').lower()


### PR DESCRIPTION
Fix PPTX export image resolution for SVGs copied from templates. When an inherited template image is not found relative to `svg_output/` or the project root, the exporter now falls back to `<project>/templates/<href>`. This covers both normal `<image>` elements and nested SVG image wrappers used for cropped template assets.

实际例子：

`skills/ppt-master/templates/decks/招商银行/01_cover.svg` 里有：

```xml
<image href="cover_bg.png" x="0" y="0" width="1280" height="720" preserveAspectRatio="xMidYMid slice"/>
```

模板复制进项目后，图片实际在：

```text
projects/<project>/templates/cover_bg.png
```

但导出原生 PPTX 时 SVG 在：

```text
projects/<project>/svg_output/01_cover.svg
```

旧逻辑只会找：

```text
projects/<project>/svg_output/cover_bg.png
projects/<project>/cover_bg.png
```

找不到就报错。现在会继续找：

```text
projects/<project>/templates/cover_bg.png
```

所以这个模板背景图可以正常嵌入到 PPTX。