### PR TITLE
fix(pdf_to_md): recognize "Figure N |" pipe-delimited captions

### DIFF
--- a/skills/ppt-master/scripts/source_to_md/pdf_to_md.py
+++ b/skills/ppt-master/scripts/source_to_md/pdf_to_md.py
@@ -340,7 +340,12 @@ VECTOR_FIGURE_DPI = 180
 VECTOR_CAPTION_SEARCH_HEIGHT = 380
 VECTOR_CAPTION_HORIZONTAL_GAP = 90
 MAX_VECTOR_BACKGROUND_AREA_RATIO = 1.9
-FIGURE_CAPTION_RE = re.compile(r'^(?:Figure|Fig\.)\s*\d+\s*[:.]', re.IGNORECASE)
+# Caption delimiters: ``Figure 1:`` / ``Figure 1.`` (classic) and ``Figure 1 |``
+# (the DeepMind / Distill / Nature house style used by many ML papers, incl.
+# full-width ``｜``). Without the pipe variants, captioned vector figures route
+# to the generic per-drawing fallback, which discards fine-grained line plots
+# (each plot is hundreds of tiny primitives, none large enough on its own).
+FIGURE_CAPTION_RE = re.compile(r'^(?:Figure|Fig\.?)\s*\d+\s*[:.|｜]', re.IGNORECASE)
 
 
 def should_keep_image(


### PR DESCRIPTION
此前的图片标题正则表达式仅匹配冒号/句点分隔符（`Figure 1:` / `Figure 1.`），因此许多机器学习论文中使用的管道分隔样式——即`Figure 1 | 标题`（DeepMind / Distill / Nature 期刊风格，也包括全角`｜`）——从未被检测到。

当无法匹配到标题时，带标题的矢量图检测便会失去锚点，回退至逐图过滤模式，而该模式会丢弃精细的矢量线图（每个图由数百个微小图元组成，单独来看没有一个足够大）。最终效果是：即便启用了`--render-vector-figures`，使用管道样式论文中的几乎所有矢量图都被丢弃了。

现将分隔符类从`[:.]`扩展为`[:.|｜]`，并使`Fig.`中的末尾句点变为可选。默认的提取行为保持不变（`--render-vector-figures`仍保持可选启用）。

The figure-caption regex only matched colon/period delimiters (`Figure 1:` / `Figure 1.`), so the pipe-delimited style used by many ML papers — `Figure 1 | Caption` (DeepMind / Distill / Nature house style, incl. full-width `｜`) — was never detected.

When no caption is matched, captioned vector-figure detection loses its anchor and falls back to per-drawing filtering, which discards fine-grained vector line plots (each plot is hundreds of tiny primitives, none large enough on its own). Net effect: papers using the pipe style had nearly all their vector figures dropped even with `--render-vector-figures` enabled.

Extend the delimiter class `[:.]` → `[:.|｜]` and make the trailing dot in `Fig.` optional. Default extraction behavior is unchanged (`--render-vector-figures` stays opt-in).