### PR TITLE
fix: keep narration volume consistent across slides

### DIFF
--- a/skills/ppt-master/SKILL.md
+++ b/skills/ppt-master/SKILL.md
@@ -598,7 +598,7 @@ Run the standalone [`customize-animations`](workflows/customize-animations.md) w
 
 **Optional recorded narration** (only when the user asks for narrated/video export):
 
-Run the standalone [`generate-audio`](workflows/generate-audio.md) workflow. The AI picks a narration backend (`edge` by default, or a configured cloud provider such as ElevenLabs / MiniMax / Qwen / CosyVoice for high-quality or cloned voices), asks the user once (backend + voice + rate/settings + embed-or-not, all with recommended values), then executes `notes_to_audio.py` and (if chosen) re-exports the PPTX with `--recorded-narration audio`.
+Run the standalone [`generate-audio`](workflows/generate-audio.md) workflow. The AI picks a narration backend (`edge` by default, or a configured cloud provider such as ElevenLabs / MiniMax / Qwen / CosyVoice for high-quality or cloned voices), asks the user once (backend + voice + rate/settings + embed-or-not, all with recommended values), then executes `notes_to_audio.py`, normalizes the per-slide narration into `audio_normalized/` by default, and (if chosen) re-exports the PPTX with `--recorded-narration audio_normalized`.
 
 Do NOT call `notes_to_audio.py` directly without going through the workflow — `--voice` / `--voice-id` is required and the workflow produces the locale/provider-aware recommendation that makes the choice meaningful.
 

--- a/skills/ppt-master/requirements.txt
+++ b/skills/ppt-master/requirements.txt
@@ -20,6 +20,9 @@ python-pptx>=0.6.21
 # notes_to_audio.py generates per-slide narration audio on macOS/Linux/Windows.
 # notes_to_audio.py 用于在 macOS/Linux/Windows 上生成逐页旁白音频。
 edge-tts>=7.2.8
+# Supplies a full FFmpeg binary with the EBU R128 `loudnorm` filter for
+# cross-slide narration loudness normalization.
+imageio-ffmpeg>=0.5.1
 
 # Office compatibility dependencies (choose one, CairoSVG preferred)
 # Office 兼容模式依赖（二选一，优先使用 cairosvg）

--- a/skills/ppt-master/scripts/normalize_narration_audio.py
+++ b/skills/ppt-master/scripts/normalize_narration_audio.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Normalize per-slide narration files to a consistent EBU R128 loudness target."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+SUPPORTED_SUFFIXES = {".mp3", ".m4a", ".wav"}
+
+
+def _run(command: list[str]) -> str:
+    # FFmpeg can emit GBK/UTF-8-mixed metadata on Windows when narration filenames
+    # contain CJK characters. Decode defensively because only its JSON payload is parsed.
+    completed = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stderr = completed.stderr.decode("utf-8", errors="replace")
+    if completed.returncode:
+        raise RuntimeError(stderr[-2000:])
+    return stderr
+
+
+def _has_loudnorm(ffmpeg: str) -> bool:
+    try:
+        completed = subprocess.run(
+            [ffmpeg, "-hide_banner", "-filters"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return completed.returncode == 0 and "loudnorm" in (completed.stdout + completed.stderr)
+
+
+def _find_ffmpeg(explicit_path: str | None) -> str:
+    candidates: list[str] = []
+    if explicit_path:
+        candidates.append(explicit_path)
+
+    try:
+        import imageio_ffmpeg  # type: ignore
+
+        candidates.append(imageio_ffmpeg.get_ffmpeg_exe())
+    except Exception:
+        pass
+
+    system_ffmpeg = shutil.which("ffmpeg")
+    if system_ffmpeg:
+        candidates.append(system_ffmpeg)
+
+    for candidate in candidates:
+        if _has_loudnorm(candidate):
+            return candidate
+
+    raise RuntimeError(
+        "No FFmpeg binary with the loudnorm filter is available. Install imageio-ffmpeg "
+        "(`python -m pip install imageio-ffmpeg`) or pass --ffmpeg <full-ffmpeg-path>."
+    )
+
+
+def _read_measurement(stderr: str) -> dict[str, str]:
+    matches = re.findall(r"\{\s*\"input_i\".*?\}", stderr, flags=re.DOTALL)
+    if not matches:
+        raise RuntimeError(f"FFmpeg did not return loudness measurement data:\n{stderr[-1200:]}")
+    return json.loads(matches[-1])
+
+
+def _output_codec(path: Path) -> list[str]:
+    suffix = path.suffix.lower()
+    if suffix == ".mp3":
+        return ["-c:a", "libmp3lame", "-b:a", "128k"]
+    if suffix == ".m4a":
+        return ["-c:a", "aac", "-b:a", "128k"]
+    if suffix == ".wav":
+        return ["-c:a", "pcm_s16le"]
+    raise ValueError(f"Unsupported narration format: {path.suffix}")
+
+
+def _normalize_one(
+    ffmpeg: str,
+    source: Path,
+    destination: Path,
+    target_lufs: float,
+    true_peak: float,
+    lra: float,
+) -> tuple[float, float]:
+    base_filter = f"loudnorm=I={target_lufs}:TP={true_peak}:LRA={lra}:print_format=json"
+    measured = _read_measurement(
+        _run([ffmpeg, "-hide_banner", "-i", str(source), "-af", base_filter, "-f", "null", "-"])
+    )
+    second_pass = (
+        f"loudnorm=I={target_lufs}:TP={true_peak}:LRA={lra}:"
+        f"measured_I={measured['input_i']}:measured_LRA={measured['input_lra']}:"
+        f"measured_TP={measured['input_tp']}:measured_thresh={measured['input_thresh']}:"
+        f"offset={measured['target_offset']}:linear=true:print_format=summary"
+    )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    _run(
+        [
+            ffmpeg,
+            "-hide_banner",
+            "-y",
+            "-i",
+            str(source),
+            "-af",
+            second_pass,
+            "-ar",
+            "32000",
+            "-ac",
+            "1",
+            *_output_codec(destination),
+            str(destination),
+        ]
+    )
+    verified = _read_measurement(
+        _run([ffmpeg, "-hide_banner", "-i", str(destination), "-af", base_filter, "-f", "null", "-"])
+    )
+    return float(measured["input_i"]), float(verified["input_i"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("audio_dir", type=Path, help="Directory containing one audio file per slide")
+    parser.add_argument("--output", type=Path, help="Destination directory; defaults to <audio_dir>_normalized")
+    parser.add_argument("--target-lufs", type=float, default=-16.0, help="Integrated loudness target (default: -16)")
+    parser.add_argument("--true-peak", type=float, default=-1.5, help="Maximum true peak in dBTP (default: -1.5)")
+    parser.add_argument("--lra", type=float, default=11.0, help="Loudness range target (default: 11)")
+    parser.add_argument("--ffmpeg", help="Path to a full FFmpeg binary with the loudnorm filter")
+    args = parser.parse_args()
+
+    source_dir = args.audio_dir.resolve()
+    if not source_dir.is_dir():
+        parser.error(f"Audio directory not found: {source_dir}")
+    destination_dir = (args.output or source_dir.with_name(f"{source_dir.name}_normalized")).resolve()
+    if destination_dir == source_dir:
+        parser.error("--output must be a different directory from audio_dir; source audio is preserved.")
+
+    sources = sorted(path for path in source_dir.iterdir() if path.is_file() and path.suffix.lower() in SUPPORTED_SUFFIXES)
+    if not sources:
+        parser.error("No .mp3, .m4a, or .wav narration files found.")
+
+    ffmpeg = _find_ffmpeg(args.ffmpeg)
+    results = []
+    for source in sources:
+        before, after = _normalize_one(ffmpeg, source, destination_dir / source.name, args.target_lufs, args.true_peak, args.lra)
+        results.append({"file": source.name, "before_lufs": round(before, 2), "after_lufs": round(after, 2)})
+        print(f"[OK] {source.name}: {before:.2f} LUFS -> {after:.2f} LUFS")
+
+    print(
+        json.dumps(
+            {
+                "files": len(results),
+                "output": str(destination_dir),
+                "target_lufs": args.target_lufs,
+                "target_true_peak_dbtp": args.true_peak,
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RuntimeError as error:
+        print(f"[Error] {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/skills/ppt-master/workflows/generate-audio.md
+++ b/skills/ppt-master/workflows/generate-audio.md
@@ -4,7 +4,7 @@ description: Generate per-slide narration audio with AI-recommended voice select
 
 # Generate Audio Workflow
 
-> Standalone post-export step. Run when the user asks for "生成音频" / "录制旁白" / "narrated PPT" / "video export with voice", or proactively offer it after a deck is exported. Produces one audio file per slide via `edge-tts` by default, or a cloud TTS provider (`elevenlabs` / `minimax` / `qwen` / `cosyvoice`) when the user chooses high-quality narration or a cloned voice, then optionally re-exports a video-ready PPTX with audio embedded and per-slide auto-advance timings.
+> Standalone post-export step. Run when the user asks for "生成音频" / "录制旁白" / "narrated PPT" / "video export with voice", or proactively offer it after a deck is exported. Produces one audio file per slide via `edge-tts` by default, or a cloud TTS provider (`elevenlabs` / `minimax` / `qwen` / `cosyvoice`) when the user chooses high-quality narration or a cloned voice. Normalize the completed files to a consistent loudness target before optionally re-exporting a video-ready PPTX with audio embedded and per-slide auto-advance timings.
 
 This workflow is **independent**: it reads `notes/*.md` and queries the selected TTS voice catalog — no upstream conversation context required. Safe to invoke in a fresh session.
 
@@ -114,7 +114,7 @@ Send a single message to the user that asks all three questions at once and prov
 
 ## Step 4: Execute (no further interaction)
 
-Run sequentially — do NOT bundle:
+Run sequentially — do NOT bundle. Preserve the raw provider output in `audio/`; normalize into a sibling directory and embed that normalized directory by default. Skip normalization only when the user explicitly asks to preserve the provider's original gain.
 
 ```bash
 # 1A. Generate audio with edge (default)
@@ -142,14 +142,21 @@ python3 skills/ppt-master/scripts/notes_to_audio.py <project_path> \
   --provider cosyvoice --voice-id <chosen-voice> \
   --cosyvoice-model cosyvoice-v3-flash
 
-# 2. (If user kept embedding) Re-export PPTX with audio embedded
+# 2. Normalize all completed narration files before embedding (default)
+# Uses two-pass EBU R128 normalization; -16 LUFS / -1.5 dBTP is the narration default.
+python3 skills/ppt-master/scripts/normalize_narration_audio.py <project_path>/audio \
+  --output <project_path>/audio_normalized
+
+# 3. (If user kept embedding) Re-export PPTX with the normalized audio embedded
 python3 skills/ppt-master/scripts/svg_to_pptx.py <project_path> \
-  --recorded-narration audio
+  --recorded-narration audio_normalized
 ```
 
 If `notes_to_audio.py` errors with a missing dependency or missing provider API key, fix the prerequisite and re-run — do NOT swallow the error.
 
-`--recorded-narration audio` prepares PowerPoint's recorded timings and narrations: every slide must have a matching supported audio file, every duration must be readable by `ffprobe`, and object animations must not use `--animation-trigger on-click`. Use `after-previous` or `with-previous` for narrated/video export.
+`normalize_narration_audio.py` keeps filenames and extensions unchanged, analyzes each file, then applies a two-pass EBU R128 correction. It writes a new directory rather than modifying `audio/`, so the original TTS audio remains available for comparison. Use `--target-lufs`, `--true-peak`, and `--lra` only when the user requests a different delivery standard.
+
+`--recorded-narration audio_normalized` prepares PowerPoint's recorded timings and narrations: every slide must have a matching supported audio file, every duration must be readable by `ffprobe`, and object animations must not use `--animation-trigger on-click`. Use `after-previous` or `with-previous` for narrated/video export.
 
 ---
 
@@ -157,7 +164,8 @@ If `notes_to_audio.py` errors with a missing dependency or missing provider API 
 
 Output one summary block listing:
 
-- Number of audio files generated and their location (`<project_path>/audio/*`).
+- Number of raw and normalized audio files plus both locations (`<project_path>/audio/*`, `<project_path>/audio_normalized/*`).
 - The provider, voice, and rate/settings actually used.
+- The loudness standard actually used (default: `-16 LUFS / -1.5 dBTP`).
 - (If embedded) the new narrated PPTX path under `<project_path>/exports/`.
-- (If skipped embedding) one-line hint on how to embed later: `python3 skills/ppt-master/scripts/svg_to_pptx.py <project_path> --recorded-narration audio`.
+- (If skipped embedding) one-line hint on how to embed later: `python3 skills/ppt-master/scripts/svg_to_pptx.py <project_path> --recorded-narration audio_normalized`.


### PR DESCRIPTION
## 问题背景

本次问题出现在 MiniMax 的分页语音合成接入流程中：即使使用相同模型、音色和语速，每页仍是一次独立合成请求，返回音频没有自动保证跨文件的播放音量一致。

实测一套 12 页中文旁白的平均播放音量存在约 1.6 LU 的页间差异。单独播放某一页未必明显；但在 PPT 自动翻页或视频连续播放时，会让听众感到前后页面的音量跳动。

这不是对 MiniMax 音色质量的否定，也不能据此推断其他 TTS 服务一定会遇到同样问题。它是将多段独立生成的音频组合成交付物时，需要补上的后处理环节。

## 解决方案

在生成旁白后、嵌入 PPTX 前：

1. 保留原始生成音频；
2. 为每一页生成一份统一播放音量的副本；
3. 将校准后的版本嵌入 PPTX。

该步骤不会改变音色、语速或文本内容；用户也可明确要求跳过它。默认设置适合以人声为主的演示文稿与课程视频：`-16 LUFS`、峰值上限 `-1.5 dBTP`。

## 变更内容

- 新增两遍 EBU R128 音频统一脚本，支持 MP3/M4A/WAV；
- 口播工作流默认在嵌入前执行该步骤；
- 保留原始音频，输出到独立的 `audio_normalized/` 目录；
- 增加 `imageio-ffmpeg`，以提供支持音量校准的完整 FFmpeg。

## 验证

- 使用 12 段真实 MiniMax 中文旁白完成端到端验证；
- 所有文件均从约 `-27.1`～`-28.7 LUFS` 收敛到约 `-16.3`～`-16.8 LUFS`；
- 通过 Python 编译检查和 Git whitespace 检查。