### PR TITLE
fix: account for letter-spacing and serif width in text box sizing (#199)

### DIFF
--- a/skills/ppt-master/scripts/svg_to_pptx/drawingml_elements.py
+++ b/skills/ppt-master/scripts/svg_to_pptx/drawingml_elements.py
@@ -800,8 +800,23 @@ def convert_text(elem: ET.Element, ctx: ConvertContext) -> ShapeResult | None:
     if not full_text.strip():
         return None
 
+    # Letter spacing — parse once, used for both box width and DrawingML spc attr
+    spc_attr = ''
+    letter_spacing = _get_attr(elem, 'letter-spacing', ctx)
+    ls_px = 0.0
+    if letter_spacing:
+        try:
+            ls_val = float(letter_spacing)
+            ls_px = ls_val * (ctx.scale_x or 1.0)
+            spc_attr = f' spc="{int(ls_val * 100)}"'
+        except ValueError:
+            pass
+
     # Estimate text dimensions
-    text_width = estimate_text_width(full_text, font_size, font_weight) * 1.15
+    text_width = estimate_text_width(
+        full_text, font_size, font_weight,
+        font_family=font_family_str, letter_spacing=ls_px,
+    ) * 1.15
     text_height = font_size * 1.5
     padding = font_size * 0.1
 
@@ -816,16 +831,6 @@ def convert_text(elem: ET.Element, ctx: ConvertContext) -> ShapeResult | None:
     box_y = y - font_size * 0.85
     box_w = text_width + padding * 2
     box_h = text_height + padding
-
-    # Letter spacing
-    spc_attr = ''
-    letter_spacing = _get_attr(elem, 'letter-spacing', ctx)
-    if letter_spacing:
-        try:
-            spc_val = float(letter_spacing) * 100
-            spc_attr = f' spc="{int(spc_val)}"'
-        except ValueError:
-            pass
 
     # Text rotation. SVG's rotate(angle [cx cy]) rotates around (cx, cy), but
     # DrawingML's <a:xfrm rot="..."> rotates the shape around its own center.

--- a/skills/ppt-master/scripts/svg_to_pptx/drawingml_utils.py
+++ b/skills/ppt-master/scripts/svg_to_pptx/drawingml_utils.py
@@ -281,8 +281,26 @@ def is_cjk_char(ch: str) -> bool:
             0x20000 <= cp <= 0x2A6DF)
 
 
-def estimate_text_width(text: str, font_size: float, font_weight: str = '400') -> float:
-    """Estimate text width in SVG pixels."""
+SERIF_FONTS = ('georgia', 'times', 'palatino', 'garamond', 'serif')
+
+
+def estimate_text_width(
+    text: str,
+    font_size: float,
+    font_weight: str = '400',
+    font_family: str = '',
+    letter_spacing: float = 0.0,
+) -> float:
+    """Estimate text width in SVG pixels.
+
+    Accounts for letter-spacing (tracking) and applies a serif-aware
+    multiplier so that wide-caps fonts like Georgia produce a text box
+    large enough for LibreOffice (which ignores ``wrap="none"``).
+    """
+    # Serif fonts have wider average glyphs than the 0.55em baseline.
+    is_serif = any(f in font_family.lower() for f in SERIF_FONTS) if font_family else False
+    serif_mul = 1.25 if is_serif else 1.0
+
     width = 0.0
     for ch in text:
         if is_cjk_char(ch):
@@ -290,14 +308,18 @@ def estimate_text_width(text: str, font_size: float, font_weight: str = '400') -
         elif ch == ' ':
             width += font_size * 0.3
         elif ch in 'mMwWOQ':
-            width += font_size * 0.75
+            width += font_size * 0.75 * serif_mul
         elif ch in 'iIlj1!|':
             width += font_size * 0.3
         else:
-            width += font_size * 0.55
+            width += font_size * 0.55 * serif_mul
 
     if font_weight in ('bold', '600', '700', '800', '900'):
         width *= 1.05
+
+    # Letter-spacing: applies to every inter-character gap.
+    if letter_spacing and len(text) > 1:
+        width += letter_spacing * (len(text) - 1)
 
     return width
 

--- a/tests/test_text_width.py
+++ b/tests/test_text_width.py
@@ -1,0 +1,100 @@
+"""Tests for text width estimation and letter-spacing handling.
+
+Covers issue #199: LibreOffice wraps text because the DrawingML text box
+is too narrow when letter-spacing is used or the font is a wide serif.
+"""
+import sys, os
+
+# Make svg_to_pptx package importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills', 'ppt-master', 'scripts'))
+
+from svg_to_pptx.drawingml_utils import estimate_text_width
+
+
+class TestEstimateTextWidth:
+    """estimate_text_width basic behaviour."""
+
+    def test_ascii_string(self):
+        w = estimate_text_width("Hello", font_size=20)
+        assert w > 0
+
+    def test_bold_wider_than_normal(self):
+        normal = estimate_text_width("PSYOPTIMAL", font_size=20, font_weight='400')
+        bold = estimate_text_width("PSYOPTIMAL", font_size=20, font_weight='700')
+        assert bold > normal
+
+    def test_cjk_char_full_width(self):
+        w = estimate_text_width("中", font_size=20)
+        assert w == 20  # 1 CJK char = font_size
+
+
+class TestLetterSpacingAware:
+    """Letter-spacing must be factored into width estimation (issue #199)."""
+
+    def test_letter_spacing_adds_width(self):
+        base = estimate_text_width("MARKET OPPORTUNITY", font_size=14)
+        with_ls = estimate_text_width(
+            "MARKET OPPORTUNITY", font_size=14, letter_spacing=2.0
+        )
+        # 18 chars → 17 gaps × 2px = 34px extra
+        assert with_ls >= base + 30
+
+    def test_zero_letter_spacing_no_change(self):
+        base = estimate_text_width("Hello", font_size=20)
+        with_zero = estimate_text_width("Hello", font_size=20, letter_spacing=0)
+        assert with_zero == base
+
+    def test_single_char_no_letter_spacing_effect(self):
+        """A single character has no inter-char gaps."""
+        base = estimate_text_width("X", font_size=20)
+        with_ls = estimate_text_width("X", font_size=20, letter_spacing=5)
+        assert with_ls == base
+
+
+class TestSerifAware:
+    """Serif fonts like Georgia have wider glyphs than the 0.55em average."""
+
+    def test_serif_wider_than_default(self):
+        default_w = estimate_text_width("PSYOPTIMAL", font_size=20)
+        serif_w = estimate_text_width(
+            "PSYOPTIMAL", font_size=20, font_family="Georgia"
+        )
+        assert serif_w > default_w
+
+    def test_times_new_roman_treated_as_serif(self):
+        default_w = estimate_text_width("MARKET OPPORTUNITY", font_size=14)
+        times_w = estimate_text_width(
+            "MARKET OPPORTUNITY", font_size=14,
+            font_family="Times New Roman"
+        )
+        assert times_w > default_w
+
+    def test_generic_sans_no_extra_width(self):
+        default_w = estimate_text_width("Hello", font_size=20)
+        arial_w = estimate_text_width("Hello", font_size=20, font_family="Arial")
+        # Arial is sans-serif — should NOT get the serif bonus
+        assert arial_w == default_w
+
+
+class TestCombinedSerifAndLetterSpacing:
+    """Both fixes together must produce a box wide enough for LibreOffice."""
+
+    def test_georgia_caps_with_tracking(self):
+        """Simulates the exact scenario from the issue report."""
+        w = estimate_text_width(
+            "PSYOPTIMAL", font_size=24,
+            font_weight='700', font_family='Georgia',
+            letter_spacing=1.5,
+        )
+        bare = estimate_text_width("PSYOPTIMAL", font_size=24, font_weight='700')
+        # Must be noticeably wider than the bare estimate
+        assert w > bare * 1.2
+
+    def test_eyebrow_label_scenario(self):
+        """Eyebrow/kicker label with tracking: 'PROJECTED BY 2030'."""
+        w = estimate_text_width(
+            "PROJECTED BY 2030", font_size=12,
+            font_family='Georgia', letter_spacing=2.5,
+        )
+        bare = estimate_text_width("PROJECTED BY 2030", font_size=12)
+        assert w > bare * 1.3


### PR DESCRIPTION
## Fix: LibreOffice wraps single-line text due to underestimated box width

Fixes #199

### Problem

When converting SVG `<text>` to DrawingML, `convert_text()` underestimates the text box width in two ways:

1. **Letter-spacing ignored** — `letter-spacing` (tracking) is parsed and applied to the DrawingML `spc` attribute, but NOT factored into the box width calculation. Eyebrow/kicker labels with 1-3px tracking add 15-50px of real width that the box doesn't account for.

2. **Serif fonts underestimated** — `estimate_text_width()` uses a 0.55em average character width, which significantly undersizes wide Georgia/serif capitals (e.g. `PSYOPTIMAL` renders as `PSYOPTIMA` / `L`).

PowerPoint ignores the issue because `<a:spAutoFit/>` shrink-wraps the frame. But **LibreOffice ignores `wrap="none"`** and wraps to the box `cx`, exposing the underestimation.

### Fix

**`drawingml_utils.py` — `estimate_text_width()`**
- Added `font_family` parameter: serif fonts (Georgia, Times, etc.) get a 1.25x multiplier on average glyph width
- Added `letter_spacing` parameter: adds `ls * (len(text) - 1)` px to account for inter-character gaps
- Both parameters are optional with zero-effect defaults, so all existing callers are unaffected

**`drawingml_elements.py` — `convert_text()`**
- Moved `letter-spacing` parsing before the width calculation so `ls_px` is available
- Passes `font_family` and `ls_px` to `estimate_text_width()`

### Tests

11 pytest cases in `tests/test_text_width.py`:
- Basic width estimation (ASCII, bold, CJK)
- Letter-spacing: adds width, zero has no effect, single-char unaffected
- Serif awareness: Georgia/Times wider, Arial unaffected
- Combined: Georgia caps + tracking, eyebrow label scenario