### PR TITLE
fix(project-manager): use name as-is when it already carries the format/date suffix

### DIFF
--- a/skills/ppt-master/scripts/project_manager.py
+++ b/skills/ppt-master/scripts/project_manager.py
@@ -132,7 +132,13 @@ class ProjectManager:
             )
 
         date_str = datetime.now().strftime("%Y%m%d")
-        project_dir_name = f"{project_name}_{normalized_format}_{date_str}"
+        # A name already carrying a `_<format>_<YYYYMMDD>` suffix (e.g. a full
+        # project dir name pasted back into init) is used as-is — re-appending
+        # would produce `name_ppt169_20260101_ppt169_20260102`.
+        if re.search(rf"_{re.escape(normalized_format)}_\d{{8}}$", project_name):
+            project_dir_name = project_name
+        else:
+            project_dir_name = f"{project_name}_{normalized_format}_{date_str}"
         project_path = base_path / project_dir_name
 
         if project_path.exists():


### PR DESCRIPTION
按 #210 第 1 条落地(维护者已确认形态)。

**问题**:`init` 无条件拼接 `_<format>_<YYYYMMDD>`,完整项目目录名粘回 init 会双后缀,且新名字绕过 `FileExistsError` 护栏静默建脏目录:

    init m01_gov_ppt169_20260626 --format ppt169
    → projects/m01_gov_ppt169_20260626_ppt169_20260626

**形态**(per review):同格式后缀原样使用;不同格式后缀照常追加(显式换画幅)。后缀识别严格——格式 token 是上方刚过 `CANVAS_FORMATS` 校验的 `normalized_format`,日期恰好 8 位数字、尾部锚定。

**验证**:`demo_ppt169_20260101`+ppt169 → 原样;`demo`+ppt169 → 正常拼接;`demo2_ppt169_20260101`+xhs → 追加 xiaohongshu 后缀。

Refs #210
