### PR TITLE
fix(images): animated-image passthrough guards + v2.12 script residues

### DIFF
--- a/skills/ppt-master/scripts/svg_finalize/align_embed_images.py
+++ b/skills/ppt-master/scripts/svg_finalize/align_embed_images.py
@@ -313,6 +313,26 @@ def _process_one_image(
     if img is None:
         return False, 'PIL open failed'
 
+    # Multi-frame images (animated GIF / WebP / APNG): every PIL transform
+    # and re-save below operates on frame 0 only, silently flattening the
+    # animation — and the "original bytes are smaller" fallback never fires
+    # because one frame is always smaller than all frames. Embed the raw
+    # bytes untouched and keep the geometry attributes (including
+    # preserveAspectRatio, which the native converter maps to srcRect
+    # non-destructively). Animated assets skip re-encode, resize, and the
+    # size cap.
+    if getattr(img, 'is_animated', False):
+        mime_type = get_mime_type(img_path.name, raw_bytes)
+        b64 = base64.b64encode(raw_bytes).decode('ascii')
+        _set_href(image, f'data:{mime_type};base64,{b64}')
+        if max_dimension and max(img.size) > max_dimension:
+            print(f'   [WARN] {img_path.name}: animated image kept as-is '
+                  f'({img.size[0]}x{img.size[1]} exceeds max dimension '
+                  f'{max_dimension}px); animations are exempt from size limits')
+        if verbose:
+            print(f'   [OK] {img_path.name} (animated, embedded as-is)')
+        return True, None
+
     box_x = _parse_float(image.get('x'))
     box_y = _parse_float(image.get('y'))
     box_w = _parse_float(image.get('width'))

--- a/skills/ppt-master/scripts/svg_finalize/embed_images.py
+++ b/skills/ppt-master/scripts/svg_finalize/embed_images.py
@@ -84,6 +84,19 @@ def _optimize_image_bytes(img_bytes: bytes, mime_type: str,
     except Exception:
         return img_bytes
 
+    # Multi-frame images (animated GIF / WebP / APNG): resize/re-save below
+    # keeps frame 0 only, silently flattening the animation. Pass the
+    # original bytes through — animations are exempt from compression and
+    # the size cap.
+    if getattr(img, 'is_animated', False):
+        if max_dimension:
+            w, h = img.size
+            if w > max_dimension or h > max_dimension:
+                print(f"  [WARN] Animated image kept as-is ({w}x{h} exceeds "
+                      f"max dimension {max_dimension}px); animations are "
+                      f"exempt from size limits")
+        return img_bytes
+
     changed = False
 
     # Downscale if exceeding max_dimension

--- a/skills/ppt-master/scripts/svg_position_calculator.py
+++ b/skills/ppt-master/scripts/svg_position_calculator.py
@@ -35,16 +35,9 @@ from pathlib import Path
 from typing import Dict, List, Tuple, Optional, Any
 from dataclasses import dataclass
 
-# Fix garbled Chinese output on Windows
-if sys.platform == 'win32':
-    try:
-        sys.stdout.reconfigure(encoding='utf-8')
-        sys.stderr.reconfigure(encoding='utf-8')
-    except AttributeError:
-        # Python < 3.7
-        import io
-        sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
-        sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
+from console_encoding import configure_utf8_stdio
+
+configure_utf8_stdio()
 
 # Import canvas format configuration
 try:

--- a/skills/ppt-master/scripts/svg_to_pptx/drawingml_elements.py
+++ b/skills/ppt-master/scripts/svg_to_pptx/drawingml_elements.py
@@ -1958,6 +1958,14 @@ def _optimize_image_for_pptx(
     except (UnidentifiedImageError, OSError, ValueError):
         return img_data, img_format
 
+    # Multi-frame images (animated GIF / WebP / APNG): resize/re-encode
+    # below keeps frame 0 only, flattening the animation in the exported
+    # PPTX. Pass the original bytes through — animations are exempt from
+    # optimization and the size cap (before this optimizer existed, the
+    # native path embedded raster bytes verbatim and animations survived).
+    if getattr(img, 'is_animated', False):
+        return img_data, img_format
+
     align, mode = _parse_preserve_aspect_ratio(elem.get('preserveAspectRatio'))
     target_w, target_h = _fit_full_image_target(
         img.size[0],

--- a/skills/ppt-master/scripts/svg_to_pptx/pptx_discovery.py
+++ b/skills/ppt-master/scripts/svg_to_pptx/pptx_discovery.py
@@ -15,8 +15,8 @@ def find_svg_files(
     Args:
         project_path: Project directory path.
         source: SVG source directory alias or name.
-            - 'output': svg_output (original version)
-            - 'final': svg_final (post-processed, recommended)
+            - 'output': svg_output (hand-authored source; native default)
+            - 'final': svg_final (post-processed; legacy SVG-image path source)
             - or any subdirectory name
 
     Returns:


### PR DESCRIPTION
按 #209 结论落地(code 部分):GIF 三守卫 + 残留 1/2。

## 动图三守卫(commit 1)

按你钉的形态:守卫键 `getattr(img, 'is_animated', False)`(覆盖 GIF / 动画 WebP / APNG,静态单帧不受影响),三处统一语义——多帧 → 跳过重编码/优化、原字节直通;超 `max_dimension` 不缩放、打 warning 说明动图不参与体积上限:

- `svg_finalize/align_embed_images.py` — 主现场;同时保留几何属性(含 `preserveAspectRatio`,native 转换器可无损映射 srcRect)
- `svg_finalize/embed_images.py::_optimize_image_bytes` — 必经二次编码点
- `svg_to_pptx/drawingml_elements.py::_optimize_image_for_pptx` — v2.12.0 native 回退现场

一处实现取舍需要你过目:`drawingml_elements` 是零 print 的纯库模块,该处守卫做成**静默直通**,用户可见 warning 由 finalize 侧两处承担(默认管线 7.2→7.3 必经,同一次运行能看到)。若希望 native 直读路径(如 resume 再导出)也有告警通道(stderr / trace_events),说个形态我补。

## 验证

- issue 同款复现物(3 帧 200x200 GIF,1110 B)逐函数字节不变
- 端到端:finalize_svg + svg_to_pptx 后,`svg_final` data URI 与导出 pptx 的 `ppt/media/*.gif` 均 `n_frames=3, is_animated=True`
- 静态单帧 GIF 对照:仍正常参与 max_dimension 缩放与压缩
- `svg_position_calculator.py --help` 冒烟通过(commit 2 替换旧手写 win32 块为 `configure_utf8_stdio()`)
- commit 3:`pptx_discovery` docstring 与 `pptx_cli` legacy 表述对齐

Refs #209
