### PR TITLE
chore(i18n): update leftover "bilingual" wording in a server.py docstring

### DIFF
--- a/skills/ppt-master/scripts/confirm_ui/server.py
+++ b/skills/ppt-master/scripts/confirm_ui/server.py
@@ -254,7 +254,7 @@ def _build_catalogs() -> dict:
     """Return the static catalog set with the canvas list synced live from
     ``config.CANVAS_FORMATS`` — the single source of truth for canvas formats —
     so the confirm page can never drift from the pipeline's real formats. The
-    set of formats and their dimensions come from config; bilingual labels and
+    set of formats and their dimensions come from config; trilingual labels and
     use text are kept from catalogs.json (with a plain fallback for any new id).
     """
     data = json.loads(_CATALOGS_PATH.read_text(encoding='utf-8'))


### PR DESCRIPTION
Tiny follow-up to #217, picking up the wording leftover noted in the merge comment: the catalogs helper docstring in `confirm_ui/server.py` still said "bilingual labels" — updated to trilingual to match the catalogs.json contract.

I swept the repo for other "bilingual" mentions while at it; the remaining two (visual-review.md and templates-architecture.md) are about mixed CJK/Latin deck content and template naming, not the UI language count, so I left them alone.