### PR TITLE
fix: deterministically backfill root <svg> width/height from viewBox

### DIFF
--- a/skills/ppt-master/references/shared-standards.md
+++ b/skills/ppt-master/references/shared-standards.md
@@ -169,7 +169,7 @@ One offending character invalidates the file and aborts export. Numeric refs (`&
 
 ## 4. Basic SVG Rules
 
-- **viewBox** must match the canvas dimensions (`width`/`height` must match `viewBox`)
+- **Root `<svg>` MUST carry explicit `width` and `height` attributes**, and both MUST equal the `viewBox` size — `viewBox="0 0 W H"` → `width="W" height="H"`. A root with only `viewBox` renders fine in browsers but trips PPT preview/export dimension detection (the live-preview banner "SVG missing width/height" fires). The finalize + live-preview pipeline auto-backfills missing `width`/`height` from `viewBox` as a safety net — do not rely on it; write them explicitly.
 - **Background**: Use `<rect>` to define the page background color
 - **`<tspan>`** has two purposes: (1) manual line breaks (use `dy` or explicit `y`); (2) inline run formatting on the same line (color/weight/size). `<foreignObject>` is FORBIDDEN. See "Single logical line" rule below.
 - **Fonts**: every `font-family` stack MUST end with a pre-installed family (Microsoft YaHei / SimSun / Arial / Times New Roman / Consolas …); `@font-face` is FORBIDDEN. Full rule: [`strategist.md §g`](strategist.md).

--- a/skills/ppt-master/scripts/finalize_svg.py
+++ b/skills/ppt-master/scripts/finalize_svg.py
@@ -31,6 +31,7 @@ Processing options:
                     merged step, so existing --only invocations keep working.
     flatten-text  - Convert <tspan> to independent <text> (for special renderers)
     fix-rounded   - Convert <rect rx="..."/> to <path> (for PPT shape conversion)
+    backfill-dims - Restore root <svg> width/height from viewBox when missing
 """
 
 import os
@@ -50,6 +51,7 @@ from svg_finalize.align_embed_images import (
     count_office_vector_refs_in_svg,
 )
 from svg_finalize.embed_icons import process_svg_file as embed_icons_in_file
+from svg_finalize.normalize_dimensions import backfill_svg_dimensions
 
 
 def safe_print(text: str) -> None:
@@ -174,7 +176,7 @@ def finalize_project(
     # Step 2: Embed icons
     if options.get('embed_icons'):
         if not quiet:
-            safe_print("[1/4] Embedding icons...")
+            safe_print("[1/5] Embedding icons...")
         icons_count = 0
         for svg_file in svg_final.glob('*.svg'):
             count = embed_icons_in_file(svg_file, icons_dir, dry_run=False, verbose=False, fallback_dir=icons_fallback_dir)
@@ -193,7 +195,7 @@ def finalize_project(
     # from disk once.
     if options.get('align_images'):
         if not quiet:
-            safe_print("[2/4] Aligning + embedding images...")
+            safe_print("[2/5] Aligning + embedding images...")
         img_count = 0
         img_errors = 0
         office_vector_count = 0
@@ -231,7 +233,7 @@ def finalize_project(
     # Step 4: Flatten text
     if options.get('flatten_text'):
         if not quiet:
-            safe_print("[3/4] Flattening text...")
+            safe_print("[3/5] Flattening text...")
         flatten_count = 0
         for svg_file in svg_final.glob('*.svg'):
             if process_flatten_text(svg_file, verbose=False):
@@ -245,7 +247,7 @@ def finalize_project(
     # Step 5: Convert rounded rects to Path
     if options.get('fix_rounded'):
         if not quiet:
-            safe_print("[4/4] Converting rounded rects to Path...")
+            safe_print("[4/5] Converting rounded rects to Path...")
         rounded_count = 0
         for svg_file in svg_final.glob('*.svg'):
             count = process_rounded_rect(svg_file, verbose=False)
@@ -255,6 +257,33 @@ def finalize_project(
                 safe_print(f"      {rounded_count} rounded rectangle(s) converted")
             else:
                 safe_print("      No rounded rectangles")
+
+    # Step 6: Backfill root <svg> width/height from viewBox (runs last so the
+    # final files carry explicit dimensions regardless of what earlier ET
+    # round-trips did). A root that omits width/height is valid, scalable SVG
+    # but trips PPT preview/export dimension detection (and the live-preview
+    # "missing width/height" banner); viewBox already holds the exact canvas
+    # size, so the backfill is lossless. See svg_finalize/normalize_dimensions.py
+    # and shared-standards.md §4.
+    if options.get('backfill_dims'):
+        if not quiet:
+            safe_print("[5/5] Backfilling root width/height...")
+        backfilled_count = 0
+        for svg_file in svg_final.glob('*.svg'):
+            try:
+                content = svg_file.read_text(encoding='utf-8')
+                new_content, changed = backfill_svg_dimensions(content)
+                if changed:
+                    svg_file.write_text(new_content, encoding='utf-8')
+                    backfilled_count += 1
+            except OSError as exc:
+                if not quiet:
+                    safe_print(f"   [ERROR] {svg_file.name}: {exc}")
+        if not quiet:
+            if backfilled_count > 0:
+                safe_print(f"      {backfilled_count} file(s) backfilled from viewBox")
+            else:
+                safe_print("      All roots already carry width/height")
 
     # Done
     if not quiet:
@@ -283,6 +312,7 @@ Processing options (for --only):
   align-images  Align (slice/meet) + Base64-embed all <image> (single pass)
   flatten-text  Flatten text
   fix-rounded   Convert rounded rects to Path
+  backfill-dims Restore root <svg> width/height from viewBox when missing
 
 Aliases (still accepted):
   crop-images, fix-aspect, embed-images  → all map to align-images
@@ -297,7 +327,7 @@ Aliases (still accepted):
             'align-images',
             # Backwards-compatible aliases — all three map to align-images now.
             'crop-images', 'fix-aspect', 'embed-images',
-            'flatten-text', 'fix-rounded',
+            'flatten-text', 'fix-rounded', 'backfill-dims',
         ],
         help=('Execute only specified processing steps (default: all). '
               'crop-images / fix-aspect / embed-images are accepted as '
@@ -334,6 +364,7 @@ Aliases (still accepted):
             'align_images': bool(only & _ALIGN_ALIASES),
             'flatten_text': 'flatten-text' in only,
             'fix_rounded': 'fix-rounded' in only,
+            'backfill_dims': 'backfill-dims' in only,
         }
     else:
         # Execute all by default
@@ -342,6 +373,7 @@ Aliases (still accepted):
             'align_images': True,
             'flatten_text': True,
             'fix_rounded': True,
+            'backfill_dims': True,
         }
 
     if args.max_dimension < 1:

--- a/skills/ppt-master/scripts/svg_editor/server.py
+++ b/skills/ppt-master/scripts/svg_editor/server.py
@@ -86,6 +86,7 @@ from embed_icons import (  # noqa: E402
     extract_paths_from_icon,
     generate_icon_group,
 )
+from normalize_dimensions import backfill_root_dimensions  # noqa: E402
 
 _ICONS_DIR = _SCRIPTS_DIR.parent.parent / 'templates' / 'icons'
 _USE_ICON_PATTERN = re.compile(r'<use\s+[^>]*data-icon="[^"]*"[^>]*/>')
@@ -549,6 +550,11 @@ def create_app(
                 logger.warning('slide parse failed: %s: %s', name, exc)
                 return jsonify({'error': f'Failed to parse SVG: {exc}'}), 500
 
+            # Deterministically restore root width/height from viewBox before
+            # serving (in memory only — svg_output on disk stays raw). Kills
+            # the "missing width/height" preview banner regardless of which
+            # model wrote the SVG. See svg_finalize/normalize_dimensions.py.
+            backfill_root_dimensions(root)
             assign_temp_ids(root)
             if pending_edits:
                 ok, reason = _apply_edit_records(root, pending_edits)

--- a/skills/ppt-master/scripts/svg_finalize/normalize_dimensions.py
+++ b/skills/ppt-master/scripts/svg_finalize/normalize_dimensions.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Backfill root ``<svg>`` ``width`` / ``height`` from ``viewBox``.
+
+A root ``<svg>`` carrying only ``viewBox`` (no ``width`` / ``height``) is valid,
+scalable SVG in browsers — which is exactly why generators omit the two
+attributes. But PPT preview/export dimension detection (and the live-preview
+"missing width/height" banner) keys off the explicit attributes. Rather than
+rely on every model strictly following ``shared-standards.md §4``, this module
+deterministically restores the attributes from ``viewBox`` wherever an
+``svg_output`` consumer ingests the file (finalize → ``svg_final`` and the
+live-preview serve path). The backfill is lossless: ``viewBox="0 0 W H"``
+already carries the exact canvas dimensions, so ``width="W" height="H"`` is the
+only correct value.
+
+Two adapters share one rule so the ET-based server path and the string-based
+finalize path cannot drift:
+
+- :func:`backfill_root_dimensions` — mutate an ``ElementTree`` root in place.
+- :func:`backfill_svg_dimensions` — rewrite raw SVG text.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["backfill_root_dimensions", "backfill_svg_dimensions"]
+
+
+def _dims_from_viewbox(viewbox: str | None) -> tuple[str, str] | None:
+    """Return ``(width, height)`` from a ``viewBox`` string, or ``None``.
+
+    Only integer ``0 0 W H`` viewBoxes yield dimensions — the same shape the
+    canvas formats emit and the quality checker compares against. Anything
+    else (fractional, offset origin, malformed) is left untouched so we never
+    invent a bogus size.
+    """
+    if not viewbox:
+        return None
+    parts = viewbox.split()
+    if len(parts) != 4:
+        return None
+    min_x, min_y, width, height = parts
+    if (min_x, min_y) != ("0", "0"):
+        return None
+    if not (width.isdigit() and height.isdigit()):
+        return None
+    if int(width) <= 0 or int(height) <= 0:
+        return None
+    return width, height
+
+
+def backfill_root_dimensions(root) -> bool:
+    """Set ``width`` / ``height`` on an ET ``<svg>`` root from ``viewBox``.
+
+    Only fills an attribute that is absent — an author-supplied ``width`` /
+    ``height`` (even a mismatched one) is preserved so this pass never
+    overrides an explicit intent. Returns ``True`` when anything changed.
+    """
+    dims = _dims_from_viewbox(root.get("viewBox"))
+    if dims is None:
+        return False
+    width, height = dims
+    changed = False
+    if not root.get("width"):
+        root.set("width", width)
+        changed = True
+    if not root.get("height"):
+        root.set("height", height)
+        changed = True
+    return changed
+
+
+def backfill_svg_dimensions(content: str) -> tuple[str, bool]:
+    """Inject missing ``width`` / ``height`` into raw SVG text.
+
+    Operates only on the root ``<svg>`` open tag (child ``width`` / ``height``
+    on ``<rect>``/``<image>`` are left alone). Returns ``(content, changed)``.
+    """
+    tag_match = re.search(r"<svg\b[^>]*>", content)
+    if tag_match is None:
+        return content, False
+    tag = tag_match.group(0)
+
+    vb_match = re.search(r'\bviewBox\s*=\s*"([^"]+)"', tag)
+    dims = _dims_from_viewbox(vb_match.group(1) if vb_match else None)
+    if dims is None:
+        return content, False
+    width, height = dims
+
+    has_width = re.search(r'\bwidth\s*=\s*"', tag) is not None
+    has_height = re.search(r'\bheight\s*=\s*"', tag) is not None
+    if has_width and has_height:
+        return content, False
+
+    injected = ""
+    if not has_width:
+        injected += f' width="{width}"'
+    if not has_height:
+        injected += f' height="{height}"'
+    new_tag = re.sub(r"^<svg\b", "<svg" + injected, tag, count=1)
+    return content[: tag_match.start()] + new_tag + content[tag_match.end() :], True

--- a/skills/ppt-master/scripts/svg_quality_checker.py
+++ b/skills/ppt-master/scripts/svg_quality_checker.py
@@ -567,9 +567,24 @@ class SVGQualityChecker:
                 break
 
     def _check_dimensions(self, content: str, result: Dict):
-        """Check width/height consistency with viewBox"""
-        width_match = re.search(r'width="(\d+)"', content)
-        height_match = re.search(r'height="(\d+)"', content)
+        """Check root <svg> width/height presence and consistency with viewBox.
+
+        Scoped to the root ``<svg>`` open tag — a bare ``width="(\\d+)"`` search
+        over the whole document would match a child ``<rect>`` and falsely
+        report the root as dimensioned. A root that omits width/height is valid
+        scalable SVG but trips PPT preview/export dim detection; the finalize +
+        live-preview pipeline auto-backfills from viewBox (see
+        svg_finalize/normalize_dimensions.py), so this is a warning (observ-
+        ability), not a hard error — erroring would false-fail decks the
+        pipeline renders correctly.
+        """
+        svg_tag_match = re.search(r'<svg\b[^>]*>', content)
+        if svg_tag_match is None:
+            return
+        svg_tag = svg_tag_match.group(0)
+
+        width_match = re.search(r'\bwidth\s*=\s*"(\d+)"', svg_tag)
+        height_match = re.search(r'\bheight\s*=\s*"(\d+)"', svg_tag)
 
         if width_match and height_match:
             width = width_match.group(1)
@@ -586,6 +601,17 @@ class SVGQualityChecker:
                             f"width/height ({width}x{height}) does not match viewBox "
                             f"({vb_width}x{vb_height})"
                         )
+            return
+
+        missing = [
+            name for name, m in (('width', width_match), ('height', height_match))
+            if m is None
+        ]
+        result['warnings'].append(
+            f"Root <svg> missing {'/'.join(missing)} attribute(s) — the pipeline "
+            f"auto-backfills from viewBox, but per shared-standards.md §4 set "
+            f"width/height explicitly on the root (both must equal viewBox)."
+        )
 
     def _check_text_elements(self, content: str, result: Dict):
         """Check text elements and wrapping methods"""

--- a/skills/ppt-master/scripts/tests/test_svg_dimensions.py
+++ b/skills/ppt-master/scripts/tests/test_svg_dimensions.py
@@ -1,0 +1,119 @@
+"""Root <svg> width/height backfill + quality-gate coverage.
+
+A root ``<svg>`` carrying only ``viewBox`` is valid scalable SVG (so models
+omit ``width``/``height``), but it trips PPT preview/export dimension detection
+and fires the live-preview "missing width/height" banner. The pipeline now
+deterministically backfills the two attributes from ``viewBox`` at every
+``svg_output`` ingress (finalize → ``svg_final`` and the live-preview serve
+path), independent of which model wrote the SVG.
+
+Run: ``python -m pytest skills/ppt-master/scripts/tests/test_svg_dimensions.py``
+"""
+
+import sys
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "svg_finalize"))
+
+from svg_finalize.normalize_dimensions import (  # noqa: E402
+    backfill_root_dimensions,
+    backfill_svg_dimensions,
+)
+from svg_quality_checker import SVGQualityChecker  # noqa: E402
+
+
+# -------------------- string adapter (finalize path) --------------------
+
+def test_string_backfill_missing_both():
+    src = '<svg viewBox="0 0 1280 720" xmlns="http://www.w3.org/2000/svg"></svg>'
+    out, changed = backfill_svg_dimensions(src)
+    assert changed is True
+    assert 'width="1280"' in out and 'height="720"' in out
+
+
+def test_string_backfill_missing_only_height():
+    out, changed = backfill_svg_dimensions('<svg width="1280" viewBox="0 0 1280 720"></svg>')
+    assert changed is True
+    assert out.count('width="1280"') == 1
+    assert 'height="720"' in out
+
+
+def test_string_backfill_present_is_noop():
+    src = '<svg width="1280" height="720" viewBox="0 0 1280 720"></svg>'
+    out, changed = backfill_svg_dimensions(src)
+    assert changed is False and out == src
+
+
+def test_string_backfill_no_viewbox_is_noop():
+    src = '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>'
+    out, changed = backfill_svg_dimensions(src)
+    assert changed is False and out == src
+
+
+def test_string_backfill_offset_viewbox_is_noop():
+    # Non-zero origin: cannot safely infer canvas width/height, leave as-is.
+    _, changed = backfill_svg_dimensions('<svg viewBox="10 10 1280 720"></svg>')
+    assert changed is False
+
+
+def test_string_backfill_ignores_child_dimensions():
+    src = '<svg viewBox="0 0 1280 720"><rect width="500" height="200" fill="#fff"/></svg>'
+    out, changed = backfill_svg_dimensions(src)
+    assert changed is True
+    root_tag = out[: out.index(">") + 1]
+    assert 'width="1280"' in root_tag and 'height="720"' in root_tag
+    assert 'width="500" height="200"' in out  # child untouched
+
+
+# -------------------- ET adapter (live-preview serve path) --------------------
+
+def test_et_backfill_sets_missing_dims():
+    root = ET.fromstring('<svg viewBox="0 0 960 540"></svg>')
+    assert backfill_root_dimensions(root) is True
+    assert root.get("width") == "960" and root.get("height") == "540"
+
+
+def test_et_backfill_preserves_existing_dims():
+    root = ET.fromstring('<svg width="800" height="600" viewBox="0 0 960 540"></svg>')
+    assert backfill_root_dimensions(root) is False
+    assert root.get("width") == "800"  # author intent preserved
+
+
+# -------------------- quality gate --------------------
+
+def _dim_result(content: str, *, viewbox: str | None = None):
+    result = {"errors": [], "warnings": [], "info": {}}
+    if viewbox is not None:
+        result["info"]["viewbox"] = viewbox
+    SVGQualityChecker()._check_dimensions(content, result)
+    return result
+
+
+def test_quality_warns_on_missing_root_dims():
+    result = _dim_result('<svg viewBox="0 0 1280 720"></svg>', viewbox="0 0 1280 720")
+    assert any("missing" in w for w in result["warnings"])
+    assert result["errors"] == []
+
+
+def test_quality_no_false_pass_on_child_width():
+    # The old whole-document regex matched the child <rect> width and silently
+    # passed. Scoped to the root tag, this must now warn.
+    content = '<svg viewBox="0 0 1280 720"><rect width="1280" height="720"/></svg>'
+    result = _dim_result(content, viewbox="0 0 1280 720")
+    assert any("missing" in w for w in result["warnings"])
+    assert "dimensions" not in result["info"]
+
+
+def test_quality_consistent_dims_no_warning():
+    content = '<svg width="1280" height="720" viewBox="0 0 1280 720"></svg>'
+    result = _dim_result(content, viewbox="0 0 1280 720")
+    assert result["warnings"] == [] and result["info"]["dimensions"] == "1280x720"
+
+
+def test_quality_mismatch_dims_warns():
+    content = '<svg width="1920" height="1080" viewBox="0 0 1280 720"></svg>'
+    result = _dim_result(content, viewbox="0 0 1280 720")
+    assert any("does not match viewBox" in w for w in result["warnings"])


### PR DESCRIPTION
## Problem

A root `<svg>` carrying only `viewBox` (no `width`/`height`) is valid, scalable SVG — which is exactly why generated slides often come out that way. But it trips PPT preview/export dimension detection:

- the **live-preview server** fires its `SVG is missing width/height attributes` banner on every such slide;
- the **quality checker** silently passes it — worse, its `width="(\d+)"` search scans the whole document and matches a child `<rect>`, so a dimensionless root **false-passes**.

Relying on every model to remember the attributes is fragile. `viewBox` already carries the exact canvas size, so restoring `width`/`height` from it is **lossless and model-independent**.

## Change (defense in depth)

- **New `svg_finalize/normalize_dimensions.py`** — viewBox → width/height backfill, with an **ET adapter** (preview serve path) and a **string adapter** (finalize) sharing one viewBox parser so they can't drift. Only integer `0 0 W H` viewBoxes are honored; an author-supplied `width`/`height` is never overridden.
- **`finalize_svg.py`** — new always-on `backfill-dims` step (runs last, over `svg_final`).
- **`svg_editor/server.py`** — backfill the root in `get_slide` before serving (in memory only; `svg_output` on disk stays raw), suppressing the banner regardless of which model wrote the SVG.
- **`svg_quality_checker._check_dimensions`** — scope the check to the root `<svg>` tag (fixes the child-`<rect>` false-pass) and **warn** instead of silently passing when the root omits `width`/`height`. It stays a warning, not an error, because the pipeline already auto-backfills — erroring would false-fail decks that render correctly.
- **`shared-standards.md §4`** — state the root MUST carry explicit `width`/`height` equal to `viewBox`, and note the pipeline auto-backfills as a safety net.

## Tests

Adds `scripts/tests/test_svg_dimensions.py` (12 tests, pure stdlib): both backfill adapters, child-element isolation, and the quality-gate behavior (warns on missing / no longer false-passes on child width / consistency / mismatch).

```
python -m pytest skills/ppt-master/scripts/tests/test_svg_dimensions.py
# 12 passed
```

Also verified end-to-end: `finalize_svg.py --only backfill-dims` restores `width="1280" height="720"` on `svg_final` while leaving the raw `svg_output` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)