### PR TITLE
fix: URL-encode page_name in fetch_slide_text for non-ASCII slide names

### DIFF
--- a/skills/ppt-master/scripts/visual_review.py
+++ b/skills/ppt-master/scripts/visual_review.py
@@ -34,6 +34,7 @@ import os
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from contextlib import contextmanager
 from pathlib import Path
@@ -114,7 +115,7 @@ def fetch_slide_text(server_url: str, page_name: str, timeout: float = 5.0) -> i
     """Probe that the server can return the slide. Returns content length.
     Used only for failure detection — the actual fetch happens inside the
     browser via fetch() so the response is parsed by JS, not Python."""
-    url = f"{server_url.rstrip('/')}/api/slide/{page_name}"
+    url = f"{server_url.rstrip('/')}/api/slide/{urllib.parse.quote(page_name)}"
     req = urllib.request.Request(url, headers={'Accept': 'application/json'})
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         payload = json.loads(resp.read().decode('utf-8'))


### PR DESCRIPTION
## What & why

`discover_pages()` returns `svg_output/*.svg` **file names** verbatim (`visual_review.py:200`), and the Python availability probe `fetch_slide_text()` interpolates them into the request URL unescaped:

```python
url = f"{server_url.rstrip('/')}/api/slide/{page_name}"
```

Any non-ASCII file name — common for Chinese decks, e.g. `03-封面页.svg` — makes `urllib.request.urlopen` raise `UnicodeEncodeError` before the request is even sent, so `render_pages()` records the slide as failed even though the server is healthy.

The in-browser path is unaffected: the injected JS uses `fetch('/api/slide/' + pageName)` and browsers percent-encode URLs automatically. This probe is the only unencoded path, so the fix is a single `urllib.parse.quote()` at the call site (plus the `urllib.parse` import).

**Reproduction:** name any slide with non-ASCII characters (e.g. `svg_output/03-封面页.svg`) and run `visual_review.py` against the project — the probe raises `UnicodeEncodeError` for that page.

## Verification

Minimal repro of the failing layer (no server needed; port 9 just proves the request leaves the URL-building stage):

```
$ python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9/api/slide/03-封面页.svg', timeout=1)"
UnicodeEncodeError: 'ascii' codec can't encode characters in position 18-20: ordinal not in range(128)

$ python3 -c "import urllib.request, urllib.parse; urllib.request.urlopen('http://127.0.0.1:9/api/slide/' + urllib.parse.quote('03-封面页.svg'), timeout=1)"
URLError (connection refused — URL builds fine, request reaches the network layer)
```

Also running this patch locally in day-to-day use on Chinese-named decks; ASCII-named slides behave identically before/after (`quote()` is a no-op for unreserved ASCII).

## Confirmations

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I personally reviewed the full diff and verified every claim in this description against this repository's actual code — including that the problem is real here and the capability isn't already provided by an existing path or already fixed on `main` (purely AI-generated PRs without human review are closed unmerged)
- [x] This PR is code-only, **or** it touches prompt/instruction text (`SKILL.md`, `references/*.md`, `workflows/*.md`, …) and was discussed and agreed in an issue first — link it here: #___

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKtEFqG74K6doBA9nbkpGR