### PR TITLE
bugfix: 将全页背景矩形改为 PowerPoint 原生底色导出

### DIFF
--- a/skills/ppt-master/scripts/svg_to_pptx/drawingml/converter.py
+++ b/skills/ppt-master/scripts/svg_to_pptx/drawingml/converter.py
@@ -13,10 +13,12 @@ from resource_paths import icon_search_dirs_for_svg
 from .context import ConvertContext, ShapeResult
 from .utils import (
     SVG_NS, EMU_PER_PX,
-    _extract_inheritable_styles, parse_transform_matrix, resolve_url_id,
+    _extract_inheritable_styles, _f, _get_attr, parse_transform_matrix, resolve_url_id,
     parse_svg_length,
 )
-from .styles import build_effect_xml
+from .styles import (
+    build_effect_xml, build_fill_xml, get_fill_opacity, get_stroke_opacity,
+)
 from .elements import (
     convert_rect, convert_circle, convert_ellipse,
     convert_line, convert_path,
@@ -361,6 +363,118 @@ _CONVERTERS = {
 _SUPPORTED_VISUAL_CHILD_TAGS = frozenset(('tspan',))
 
 
+def _parse_svg_canvas(root: ET.Element) -> tuple[float, float, float, float]:
+    """Return the SVG canvas as (x, y, width, height) in SVG units."""
+    view_box = root.get('viewBox', '')
+    parts = re.split(r'[\s,]+', view_box.strip()) if view_box else []
+    if len(parts) == 4:
+        try:
+            x, y, w, h = (float(part) for part in parts)
+            if w > 0 and h > 0:
+                return x, y, w, h
+        except ValueError:
+            pass
+    return 0.0, 0.0, _f(root.get('width')), _f(root.get('height'))
+
+
+def _is_full_canvas_rect(
+    elem: ET.Element,
+    ctx: ConvertContext,
+    canvas: tuple[float, float, float, float],
+) -> bool:
+    """Return whether a rect is a safe candidate for native slide background."""
+    if elem.get('transform') or elem.get('filter') or elem.get('clip-path'):
+        return False
+    if _f(elem.get('rx')) > 0 or _f(elem.get('ry')) > 0:
+        return False
+
+    canvas_x, canvas_y, canvas_w, canvas_h = canvas
+    if canvas_w <= 0 or canvas_h <= 0:
+        return False
+
+    tolerance = 0.5
+    if abs(_f(elem.get('x')) - canvas_x) > tolerance:
+        return False
+    if abs(_f(elem.get('y')) - canvas_y) > tolerance:
+        return False
+    if abs(_f(elem.get('width')) - canvas_w) > tolerance:
+        return False
+    if abs(_f(elem.get('height')) - canvas_h) > tolerance:
+        return False
+
+    fill = _get_attr(elem, 'fill', ctx)
+    if fill == 'none':
+        return False
+
+    stroke = _get_attr(elem, 'stroke', ctx)
+    stroke_width = _f(_get_attr(elem, 'stroke-width', ctx), 1.0)
+    stroke_opacity = get_stroke_opacity(elem, ctx)
+    if stroke and stroke != 'none' and stroke_width > 0 and stroke_opacity != 0:
+        return False
+
+    return True
+
+
+def _background_xml_from_rect(
+    elem: ET.Element,
+    ctx: ConvertContext,
+) -> str:
+    """Build native ``p:bg`` XML from a full-slide SVG background rect."""
+    fill_xml = build_fill_xml(elem, ctx, get_fill_opacity(elem, ctx))
+    if not fill_xml or '<a:noFill' in fill_xml:
+        return ''
+    return f'<p:bg><p:bgPr>{fill_xml}</p:bgPr></p:bg>'
+
+
+def _extract_background_candidate(
+    root: ET.Element,
+    ctx: ConvertContext,
+) -> tuple[str, int | None]:
+    """Promote a first-layer SVG background rect to native PowerPoint bgPr.
+
+    PowerPoint stores page background fills under ``p:cSld/p:bg/p:bgPr``.
+    Keeping the full-canvas SVG rect in ``p:spTree`` makes it an ordinary
+    selectable shape, so users hit it during bulk element selection. Only the
+    first visual layer is considered, matching pptx_to_svg's round-trip output
+    and avoiding accidental promotion of content panels.
+    """
+    canvas = _parse_svg_canvas(root)
+    for child in root:
+        tag = child.tag.replace(f'{{{SVG_NS}}}', '')
+        if tag in _NON_VISUAL_TAGS:
+            continue
+
+        if tag == 'rect' and _is_full_canvas_rect(child, ctx, canvas):
+            bg_xml = _background_xml_from_rect(child, ctx)
+            if bg_xml:
+                return bg_xml, id(child)
+            return '', None
+
+        if tag != 'g':
+            return '', None
+        if child.get('transform') or child.get('filter') or child.get('clip-path'):
+            return '', None
+        style_overrides = _extract_inheritable_styles(child)
+        child_ctx = ctx.child(style_overrides=style_overrides)
+        visual_children = [
+            grandchild for grandchild in child
+            if grandchild.tag.replace(f'{{{SVG_NS}}}', '') not in _NON_VISUAL_TAGS
+        ]
+        if len(visual_children) != 1:
+            return '', None
+        only_child = visual_children[0]
+        only_tag = only_child.tag.replace(f'{{{SVG_NS}}}', '')
+        if only_tag == 'rect' and _is_full_canvas_rect(only_child, child_ctx, canvas):
+            bg_xml = _background_xml_from_rect(only_child, child_ctx)
+            if bg_xml:
+                ctx.sync_from_child(child_ctx)
+                return bg_xml, id(child)
+            return '', None
+        return '', None
+
+    return '', None
+
+
 def collect_defs(root: ET.Element) -> dict[str, ET.Element]:
     """Collect all <defs> children into an {id: element} dictionary."""
     defs: dict[str, ET.Element] = {}
@@ -568,6 +682,13 @@ def convert_svg_to_slide_shapes(
     shapes: list[str] = []
     converted = 0
     skipped = 0
+    background_xml, background_skip_id = _extract_background_candidate(root, ctx)
+    if background_xml and trace_events is not None:
+        trace_events.append({
+            'tag': 'rect',
+            'decision': 'native-background',
+            'reason': 'promoted-full-canvas-rect-to-bgPr',
+        })
     # Per-element shape ids of every top-level child, used as an animation
     # fallback when no <g id="..."> groups are present at the root.
     fallback_targets: list = []
@@ -575,6 +696,9 @@ def convert_svg_to_slide_shapes(
     for child in root:
         tag = child.tag.replace(f'{{{SVG_NS}}}', '')
         if tag == 'defs':
+            continue
+        if id(child) == background_skip_id:
+            skipped += 1
             continue
         result = convert_element(child, ctx)
         if result:
@@ -623,6 +747,7 @@ def convert_svg_to_slide_shapes(
        xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
        xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
 <p:cSld>
+{background_xml}
 <p:spTree>
 <p:nvGrpSpPr>
 <p:cNvPr id="1" name=""/>


### PR DESCRIPTION
【问题背景】
在实际导出 PPTX 文件并进行二次编辑时，我发现每一页都会生成一个覆盖整页的底层图形对象。
该对象在视觉上表现为页面底色，但在 PowerPoint 中却被导出为普通 shape，进入了页面的可编辑对象树。
因此在进行批量框选、拖拽或调整页面元素时，鼠标经常会优先选中这个全页底图块，干扰正常编辑操作。

从语义上看，这一层并不应该作为独立 shape 存在。它只是页面背景色，应当写入 PowerPoint 原生的 slide background 结构，而不是被单独绘制成一个可选中的矩形对象。
当前导出结果虽然视觉上接近预期，但对象结构不合理，导致编辑体验和 PPTX 原生语义都不正确。

## What & why

修复 `svg_to_pptx` 原生 PPTX 导出时，将 SVG 第一层全画布背景矩形导出为普通 shape 的问题。

此前每页背景色会作为覆盖整页的矩形进入 `p:spTree`，导致在 PowerPoint 中批量框选或移动元素时容易误选中底图块。直接删除该矩形会破坏有背景色的页面，因此本次改为在转换阶段识别安全的全画布背景 rect，并提升为 PowerPoint 原生背景 `p:cSld/p:bg/p:bgPr`，同时跳过其普通 shape 导出。

该逻辑只处理第一层、覆盖完整画布、无描边、无圆角、无变换、无滤镜、无裁剪且可转换填充的背景矩形，避免误吞卡片、面板或装饰元素。

## Verification

本地已验证：

- 运行 `python -m py_compile skills/ppt-master/scripts/svg_to_pptx/drawingml_converter.py`，通过。
- 运行 `git diff --check`，通过，仅出现 Git 的 CRLF 提示。
- 使用 `projects/ai_for_ppt_landscape_ppt169_20260701/svg_output` 执行导出：
  `python skills/ppt-master/scripts/svg_to_pptx.py projects/ai_for_ppt_landscape_ppt169_20260701`
- 导出 12 页全部成功。
- 拆包检查导出的 PPTX：
  - 12 页均包含 `p:cSld/p:bg/p:bgPr`
  - 背景色均为 `F7F8FA`
  - `p:spTree` 中全画布普通 shape 数量为 `0`

## Confirmations

**All three of the following must be checked. If any one is left unchecked, the PR is closed without review.**

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I personally reviewed the full diff and verified every claim in this description against this repository's actual code — including that the problem is real here and the capability isn't already provided by an existing path or already fixed on `main` (purely AI-generated PRs without human review are closed unmerged)
- [x] This PR is code-only, **or** it touches prompt/instruction text (`SKILL.md`, `references/*.md`, `workflows/*.md`, …) and was discussed and agreed in an issue first — link it here: #___


附图：
【原始】能看到会有一个底图，鼠标每次想批量款一些元素时，总是把它框住。
<img width="1427" height="856" alt="image" src="https://github.com/user-attachments/assets/84de805b-0fc9-40df-aad4-55a2ee080574" />

【修改】
<img width="1398" height="783" alt="image" src="https://github.com/user-attachments/assets/eb267047-2f92-4c8a-a98c-d38d7735f02b" />


附件：
[修改_ai_for_ppt_landscape_20260707_175323.pptx](https://github.com/user-attachments/files/29743518/_ai_for_ppt_landscape_20260707_175323.pptx)
[原始_ai_for_ppt_landscape_20260701_153608.pptx](https://github.com/user-attachments/files/29743522/_ai_for_ppt_landscape_20260701_153608.pptx)