### PR TITLE
fix: harden beautify local export qa

### DIFF
--- a/skills/ppt-master/scripts/confirm_ui/server.py
+++ b/skills/ppt-master/scripts/confirm_ui/server.py
@@ -44,7 +44,13 @@ import webbrowser
 from pathlib import Path
 from typing import Optional
 
-from flask import Flask, jsonify, request, send_from_directory
+try:
+    from flask import Flask, jsonify, request, send_from_directory
+except ImportError:
+    Flask = None
+    jsonify = None
+    request = None
+    send_from_directory = None
 
 # Local — sys.path injection for sibling module (code-style.md §3)
 _SCRIPTS_DIR = Path(__file__).resolve().parent.parent
@@ -139,7 +145,7 @@ def _wait_for_result(
 def _result_stage(result_file: Path) -> Optional[str]:
     """Return the canonical ``stage`` field of result.json, or None."""
     try:
-        data = json.loads(result_file.read_text(encoding='utf-8'))
+        data = _read_json_lenient(result_file)
     except (OSError, json.JSONDecodeError):
         return None
     return _stage_key(data.get('stage')) if isinstance(data, dict) else None
@@ -188,7 +194,7 @@ _DESIGN_RECOMMEND_KEYS = ('icons', 'formula_policy')
 def _merge_confirmed_choices(data: dict, result_file: Path) -> None:
     """Fold already-confirmed choices into later-stage recommendations."""
     try:
-        res = json.loads(result_file.read_text(encoding='utf-8'))
+        res = _read_json_lenient(result_file)
     except (OSError, json.JSONDecodeError):
         return
     if not isinstance(res, dict):
@@ -389,14 +395,118 @@ def _build_ai_image_comparison() -> dict:
     }
 
 
+def _build_style_previews() -> dict:
+    """Inline visual-style preview SVGs for local HTML mode."""
+    preview_dir = Path(__file__).resolve().parent / 'static' / 'style_previews'
+    previews = {}
+    for path in preview_dir.glob('*.svg'):
+        try:
+            previews[path.stem] = path.read_text(encoding='utf-8')
+        except OSError:
+            continue
+    return previews
+
+
+def _read_json_lenient(path: Path) -> dict:
+    """Read JSON written by shells/editors that may prepend a UTF-8 BOM."""
+    return json.loads(path.read_text(encoding='utf-8-sig'))
+
+
+def _write_json_utf8(path: Path, data: dict) -> None:
+    """Write JSON as UTF-8 without BOM."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2) + '\n',
+        encoding='utf-8',
+    )
+
+
+def _import_local_result(project_path: Path, source: Path) -> Path:
+    """Import a local-HTML downloaded result.json into the project."""
+    data = _read_json_lenient(source)
+    if not isinstance(data, dict):
+        raise ValueError('result JSON must be an object')
+    stage = _stage_key(data.get('stage'))
+    if stage not in {'stage1', 'stage2', 'final'}:
+        data['stage'] = 'final'
+    if data.get('stage') in {'stage1', 'stage2'}:
+        data['status'] = f"{data['stage']}-confirmed"
+    else:
+        data['stage'] = 'final'
+        data['status'] = 'confirmed'
+    data.setdefault('confirmed_at', time.strftime('%Y-%m-%dT%H:%M:%S'))
+    result_file = project_path / CONFIRM_DIR_NAME / RESULT_NAME
+    _write_json_utf8(result_file, data)
+    return result_file
+
+
+def _build_local_html(project_path: Path, output: Optional[Path] = None) -> Path:
+    """Write a self-contained local confirmation page into the project.
+
+    The local page is a fallback for Windows/Python environments where the
+    Flask server cannot start. It embeds the current recommendations and
+    catalogs directly, so users can open it with ``file://``. Because browsers
+    cannot silently write local files from ``file://`` pages, confirmation
+    downloads ``result.json`` and also shows the JSON on screen for saving.
+    """
+    confirm_dir = project_path / CONFIRM_DIR_NAME
+    rec_file = confirm_dir / RECOMMENDATIONS_NAME
+    if not rec_file.exists():
+        raise FileNotFoundError(f'{rec_file} not found')
+    confirm_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output or (confirm_dir / 'confirm_local.html')
+
+    static_dir = Path(__file__).resolve().parent / 'static'
+    index_html = (static_dir / 'index.html').read_text(encoding='utf-8')
+    style_css = (static_dir / 'style.css').read_text(encoding='utf-8')
+    app_js = (static_dir / 'app.js').read_text(encoding='utf-8')
+
+    payload = {
+        'recommendations': _read_json_lenient(rec_file),
+        'catalogs': _build_catalogs(),
+        'iconPreviews': _build_icon_previews(),
+        'aiImageComparison': _build_ai_image_comparison(),
+        'stylePreviews': _build_style_previews(),
+    }
+    data_script = (
+        '<script>\n'
+        'window.PPT_MASTER_LOCAL_DATA = '
+        + json.dumps(payload, ensure_ascii=False)
+        + ';\n</script>'
+    )
+
+    html = index_html
+    html = re.sub(
+        r'<link\s+rel="stylesheet"\s+href="/static/style\.css"\s*/?>',
+        lambda _match: '<style>\n' + style_css + '\n</style>',
+        html,
+        count=1,
+    )
+    html = re.sub(
+        r'<script\s+src="/static/app\.js"></script>',
+        lambda _match: data_script + '\n<script>\n' + app_js + '\n</script>',
+        html,
+        count=1,
+    )
+    # Some old mojibake in the static template can leave malformed visible
+    # glyphs; keep generated HTML parseable and self-contained.
+    if '<script src="/static/app.js"></script>' in html:
+        html += '\n' + data_script + '\n<script>\n' + app_js + '\n</script>\n'
+
+    output_path.write_text(html, encoding='utf-8')
+    return output_path
+
+
 # --- app --------------------------------------------------------------------
 
 def create_app(
     project_dir: str,
     idle_timeout: int = 900,
     lock_file: Optional[Path] = None,
-) -> Flask:
+) -> "Flask":
     """Create and configure the Flask app for a given project directory."""
+    if Flask is None:
+        raise RuntimeError("Flask is required for server mode. Use --local-html to generate an offline page.")
     project_path = Path(project_dir).resolve()
     confirm_dir = project_path / CONFIRM_DIR_NAME
 
@@ -489,7 +599,7 @@ def create_app(
         if not rec_file.exists():
             return jsonify({'error': 'recommendations not found'}), 404
         try:
-            data = json.loads(rec_file.read_text(encoding='utf-8'))
+            data = json.loads(rec_file.read_text(encoding='utf-8-sig'))
         except (OSError, json.JSONDecodeError) as exc:
             return jsonify({'error': f'invalid recommendations.json: {exc}'}), 400
         # Report whether a result already exists (re-open after confirm).
@@ -527,10 +637,7 @@ def create_app(
             result['status'] = 'confirmed'
         result['confirmed_at'] = time.strftime('%Y-%m-%dT%H:%M:%S')
         result_file = confirm_dir / RESULT_NAME
-        result_file.write_text(
-            json.dumps(result, ensure_ascii=False, indent=2),
-            encoding='utf-8',
-        )
+        _write_json_utf8(result_file, result)
         logger.info('%s confirmation written to %s', result['stage'], result_file)
         return jsonify({'status': 'ok'})
 
@@ -581,6 +688,19 @@ def build_parser() -> argparse.ArgumentParser:
              '(idempotent). Run at the end of Step 4 so the page never lingers '
              'on the shared port before live preview starts.',
     )
+    parser.add_argument(
+        '--local-html', action='store_true',
+        help='Write a self-contained confirm_local.html that can be opened from '
+             'the filesystem without running Flask.',
+    )
+    parser.add_argument(
+        '--local-output', default=None,
+        help='Output path for --local-html. Default: <project>/confirm_ui/confirm_local.html.',
+    )
+    parser.add_argument(
+        '--import-result', default=None,
+        help='Import a result.json downloaded from --local-html into <project>/confirm_ui/result.json.',
+    )
     return parser
 
 
@@ -598,6 +718,23 @@ def main(argv: Optional[list[str]] = None) -> int:
     if not project_path.is_dir():
         logger.error('%s is not a directory', project_path)
         return 1
+    if args.import_result:
+        try:
+            result_file = _import_local_result(project_path, Path(args.import_result).resolve())
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            logger.error('failed to import local result: %s', exc)
+            return 1
+        logger.info('local result imported: %s', result_file)
+        return 0
+    if args.local_html:
+        try:
+            output = Path(args.local_output).resolve() if args.local_output else None
+            html_path = _build_local_html(project_path, output)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.error('failed to write local confirm HTML: %s', exc)
+            return 1
+        logger.info('local confirm HTML written: %s', html_path)
+        return 0
     wait_stage = _stage_key(args.wait_stage)
     if wait_stage not in {'stage2', 'final'}:
         logger.error('--wait-stage must be stage2 or final')

--- a/skills/ppt-master/scripts/confirm_ui/static/app.js
+++ b/skills/ppt-master/scripts/confirm_ui/static/app.js
@@ -8,6 +8,9 @@
 (function () {
     "use strict";
 
+    var LOCAL_DATA = window.PPT_MASTER_LOCAL_DATA || null;
+    function isLocalMode() { return !!LOCAL_DATA; }
+
     // ---- i18n ------------------------------------------------------------
     var MESSAGES = {
         en: {
@@ -512,6 +515,10 @@
     }
 
     function visualStylePreviewSrc(id) {
+        if (isLocalMode()) {
+            var svg = LOCAL_DATA.stylePreviews && LOCAL_DATA.stylePreviews[id || ""];
+            if (svg) return "data:image/svg+xml;charset=utf-8," + encodeURIComponent(svg);
+        }
         return "/static/style_previews/" + encodeURIComponent(id || "") + ".svg";
     }
 
@@ -2098,6 +2105,69 @@
         ov.style.display = "flex";
     }
 
+    function normalizeSubmittedResult(payload) {
+        var result = JSON.parse(JSON.stringify(payload));
+        var rawStage = String(result.stage || "").toLowerCase();
+        if (rawStage === "stage1" || rawStage === "stage2") {
+            result.status = rawStage + "-confirmed";
+        } else {
+            result.stage = "final";
+            result.status = "confirmed";
+        }
+        result.confirmed_at = new Date().toISOString().replace(/\.\d{3}Z$/, "");
+        return result;
+    }
+
+    function downloadResultJson(result) {
+        var json = JSON.stringify(result, null, 2);
+        var blob = new Blob([json + "\n"], { type: "application/json;charset=utf-8" });
+        var a = document.createElement("a");
+        a.href = URL.createObjectURL(blob);
+        a.download = "result.json";
+        document.body.appendChild(a);
+        a.click();
+        setTimeout(function () {
+            URL.revokeObjectURL(a.href);
+            a.remove();
+        }, 1000);
+        return json;
+    }
+
+    function showLocalResult(result) {
+        var json = downloadResultJson(result);
+        var ov = document.getElementById("confirmed-overlay");
+        ov.querySelector(".cf-title").textContent = t("confirmed_title");
+        ov.querySelector(".cf-hint").innerHTML =
+            "本地 HTML 已下载 <code>result.json</code>。也可以复制下面 JSON，或用命令 <code>--import-result</code> 导入下载文件。";
+        var pre = document.createElement("pre");
+        pre.style.cssText = "max-height:45vh;overflow:auto;text-align:left;white-space:pre-wrap;background:#0c1020;color:#e8eefc;padding:12px;border-radius:8px;margin-top:12px;font-size:12px;";
+        pre.textContent = json;
+        var copyBtn = document.createElement("button");
+        copyBtn.type = "button";
+        copyBtn.className = "btn-primary";
+        copyBtn.style.marginTop = "12px";
+        copyBtn.textContent = "复制 JSON";
+        copyBtn.addEventListener("click", function () {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(json).then(function () {
+                    copyBtn.textContent = "已复制";
+                }).catch(function () {
+                    copyBtn.textContent = "复制失败，请手动选择";
+                });
+            } else {
+                copyBtn.textContent = "请手动选择复制";
+            }
+        });
+        var card = ov.querySelector(".cf-card");
+        var old = card.querySelector("pre");
+        if (old) old.remove();
+        var oldBtn = card.querySelector(".btn-primary");
+        if (oldBtn) oldBtn.remove();
+        card.appendChild(pre);
+        card.appendChild(copyBtn);
+        ov.style.display = "flex";
+    }
+
     // ---- staged submit + re-derive transitions --------------------------
     function stage1Payload() {
         var payload = {
@@ -2133,6 +2203,10 @@
     }
 
     function submitStage(payload, nextStage) {
+        if (isLocalMode()) {
+            showLocalResult(normalizeSubmittedResult(payload));
+            return;
+        }
         var btn = document.getElementById("btn-confirm");
         btn.disabled = true;
         fetch("/api/confirm", {
@@ -2207,6 +2281,10 @@
             delete payload.image_ai_path;
             delete payload.image_strategy;
         }
+        if (isLocalMode()) {
+            showLocalResult(normalizeSubmittedResult(payload));
+            return;
+        }
         btn.disabled = true;
         fetch("/api/confirm", {
             method: "POST",
@@ -2236,18 +2314,21 @@
     }
 
     function loadCatalogs() {
+        if (isLocalMode()) return Promise.resolve(LOCAL_DATA.catalogs || {});
         return fetch("/api/catalogs")
             .then(function (r) { if (r.ok) return r.json(); throw new Error("no api"); })
             .catch(function () { return fetch("/static/catalogs.json").then(function (r) { return r.json(); }); });
     }
 
     function loadIconPreviews() {
+        if (isLocalMode()) return Promise.resolve(LOCAL_DATA.iconPreviews || {});
         return fetch("/api/icon-previews")
             .then(function (r) { if (r.ok) return r.json(); throw new Error("no icon preview api"); })
             .catch(function () { return {}; });
     }
 
     function loadAiImageComparison() {
+        if (isLocalMode()) return Promise.resolve(LOCAL_DATA.aiImageComparison || {});
         return fetch("/api/ai-image-comparison")
             .then(function (r) { if (r.ok) return r.json(); throw new Error("no ai image comparison api"); })
             .catch(function () { return {}; });
@@ -2337,7 +2418,9 @@
 
         Promise.all([
             loadCatalogs(),
-            fetch("/api/recommendations").then(function (r) { if (!r.ok) throw new Error("load failed"); return r.json(); }),
+            isLocalMode()
+                ? Promise.resolve(LOCAL_DATA.recommendations || {})
+                : fetch("/api/recommendations").then(function (r) { if (!r.ok) throw new Error("load failed"); return r.json(); }),
             loadIconPreviews(),
             loadAiImageComparison()
         ]).then(function (res) {

--- a/skills/ppt-master/scripts/export_qa.py
+++ b/skills/ppt-master/scripts/export_qa.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+PPT Master - Export QA Gate
+
+Runs final delivery checks for a project: SVG XML parse, svg_quality_checker,
+optional beautify text fidelity, and optional PPTX open/page-count verification.
+Writes a compact Markdown report under exports/.
+
+Usage:
+    python3 scripts/export_qa.py <project_path>
+    python3 scripts/export_qa.py <project_path> --beautify
+    python3 scripts/export_qa.py <project_path> --pptx exports/out.pptx --beautify
+
+Examples:
+    python3 scripts/export_qa.py projects/recruitment --beautify
+    python3 scripts/export_qa.py projects/recruitment --pptx latest --beautify
+
+Dependencies:
+    python-pptx (only when --pptx is supplied)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from console_encoding import configure_utf8_stdio
+
+configure_utf8_stdio()
+
+
+def _scripts_dir() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def _run(cmd: list[str], cwd: Path) -> tuple[int, str]:
+    proc = subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    return proc.returncode, proc.stdout
+
+
+def _xml_check(project_path: Path) -> tuple[bool, list[str]]:
+    svg_dir = project_path / "svg_output"
+    failures = []
+    for svg_file in sorted(svg_dir.glob("*.svg")):
+        try:
+            ET.parse(svg_file)
+        except ET.ParseError as exc:
+            failures.append(f"{svg_file.name}: {exc}")
+    return not failures, failures
+
+
+def _latest_pptx(project_path: Path) -> Path | None:
+    exports = project_path / "exports"
+    files = sorted(exports.glob("*.pptx"), key=lambda p: p.stat().st_mtime, reverse=True)
+    return files[0] if files else None
+
+
+def _resolve_pptx(project_path: Path, value: str | None) -> Path | None:
+    if not value:
+        return None
+    if value == "latest":
+        return _latest_pptx(project_path)
+    path = Path(value)
+    if not path.is_absolute():
+        path = project_path / path
+    return path
+
+
+def _pptx_check(path: Path | None, expected_pages: int | None) -> tuple[bool, str]:
+    if path is None:
+        return True, "Skipped"
+    if not path.exists():
+        return False, f"Missing PPTX: {path}"
+    try:
+        from pptx import Presentation
+    except ImportError as exc:
+        return False, f"python-pptx unavailable: {exc}"
+    try:
+        prs = Presentation(str(path))
+    except Exception as exc:  # noqa: BLE001 - user-facing file validation
+        return False, f"Cannot open PPTX: {exc}"
+    count = len(prs.slides)
+    if expected_pages is not None and count != expected_pages:
+        return False, f"Slide count {count}, expected {expected_pages}"
+    return True, f"Opened OK, slides={count}"
+
+
+def _expected_page_count(project_path: Path) -> int | None:
+    source_clean = project_path / "analysis" / "source_text_clean.json"
+    if source_clean.exists():
+        try:
+            data = json.loads(source_clean.read_text(encoding="utf-8-sig"))
+            return len(data.get("slides", []))
+        except (OSError, json.JSONDecodeError):
+            return None
+    return None
+
+
+def _write_report(project_path: Path, rows: list[tuple[str, bool, str]]) -> Path:
+    exports = project_path / "exports"
+    exports.mkdir(parents=True, exist_ok=True)
+    path = exports / "qa_report.md"
+    lines = [
+        "# Export QA Report",
+        "",
+        "| Check | Status | Detail |",
+        "| --- | --- | --- |",
+    ]
+    for name, ok, detail in rows:
+        status = "PASS" if ok else "FAIL"
+        safe_detail = detail.replace("|", "\\|").replace("\n", "<br>")
+        lines.append(f"| {name} | {status} | {safe_detail} |")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run final export QA checks.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("project_path", help="PPT Master project directory")
+    parser.add_argument("--beautify", action="store_true", help="Run beautify text fidelity gate")
+    parser.add_argument("--pptx", default=None, help="PPTX path to verify, or 'latest'")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    project_path = Path(args.project_path).resolve()
+    if not project_path.is_dir():
+        print(f"[ERROR] Project not found: {project_path}", file=sys.stderr)
+        return 2
+
+    rows: list[tuple[str, bool, str]] = []
+    xml_ok, xml_failures = _xml_check(project_path)
+    rows.append(("SVG XML parse", xml_ok, "OK" if xml_ok else "\n".join(xml_failures[:20])))
+
+    code, output = _run(
+        [sys.executable, str(_scripts_dir() / "svg_quality_checker.py"), str(project_path)],
+        cwd=_scripts_dir().parents[2],
+    )
+    rows.append(("SVG quality checker", code == 0, "Exit 0" if code == 0 else output[-2000:]))
+
+    code, output = _run(
+        [sys.executable, str(_scripts_dir() / "svg_layout_safety.py"), str(project_path), "--write-report"],
+        cwd=_scripts_dir().parents[2],
+    )
+    rows.append(("SVG layout safety", code == 0, "Exit 0" if code == 0 else output[-2000:]))
+
+    if args.beautify:
+        cmd = [
+            sys.executable,
+            str(_scripts_dir() / "verify_beautify_fidelity.py"),
+            str(project_path),
+            "--write-report",
+        ]
+        pptx_path = _resolve_pptx(project_path, args.pptx)
+        if pptx_path is not None:
+            cmd.extend(["--target-pptx", str(pptx_path)])
+        code, output = _run(cmd, cwd=_scripts_dir().parents[2])
+        rows.append(("Beautify text fidelity", code == 0, "Exit 0" if code == 0 else output[-2000:]))
+
+    pptx_path = _resolve_pptx(project_path, args.pptx)
+    pptx_ok, pptx_detail = _pptx_check(pptx_path, _expected_page_count(project_path))
+    rows.append(("PPTX open/page count", pptx_ok, pptx_detail))
+
+    report_path = _write_report(project_path, rows)
+    for name, ok, detail in rows:
+        print(f"[{'OK' if ok else 'FAIL'}] {name}: {detail.splitlines()[0] if detail else ''}")
+    print(f"Report: {report_path}")
+    return 0 if all(ok for _, ok, _ in rows) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ppt-master/scripts/finalize_svg.py
+++ b/skills/ppt-master/scripts/finalize_svg.py
@@ -161,8 +161,14 @@ def finalize_project(
 
     # Step 1: Copy directory
     if svg_final.exists():
-        shutil.rmtree(svg_final)
-    shutil.copytree(svg_output, svg_final)
+        try:
+            shutil.rmtree(svg_final)
+        except PermissionError:
+            # Windows can briefly keep an empty output directory locked by
+            # Explorer / preview tooling.  Continue with an overwrite copy so
+            # generated decks are not blocked by a stale directory handle.
+            pass
+    shutil.copytree(svg_output, svg_final, dirs_exist_ok=True)
 
     if not quiet:
         print()

--- a/skills/ppt-master/scripts/svg_layout_safety.py
+++ b/skills/ppt-master/scripts/svg_layout_safety.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+PPT Master - SVG Layout Safety Check
+
+Scans generated SVG pages for obvious text/image overlaps. This is a lightweight
+geometry heuristic for catching common beautify failures before export; it does
+not replace visual review.
+
+Usage:
+    python3 scripts/svg_layout_safety.py <project_path>
+    python3 scripts/svg_layout_safety.py <project_path> --write-report
+
+Examples:
+    python3 scripts/svg_layout_safety.py projects/recruitment --write-report
+
+Dependencies:
+    None
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree as ET
+
+from console_encoding import configure_utf8_stdio
+
+configure_utf8_stdio()
+
+_NUM_RE = re.compile(r"^-?\d+(?:\.\d+)?")
+
+
+def _float(value: str | None, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    match = _NUM_RE.match(str(value).strip())
+    return float(match.group(0)) if match else default
+
+
+def _text_content(node: ET.Element) -> str:
+    pieces = []
+    if node.text:
+        pieces.append(node.text)
+    for child in list(node):
+        if child.text:
+            pieces.append(child.text)
+        if child.tail:
+            pieces.append(child.tail)
+    return "".join(pieces).strip()
+
+
+def _text_box(node: ET.Element) -> tuple[float, float, float, float] | None:
+    text = _text_content(node)
+    if not text:
+        return None
+    x = _float(node.get("x"))
+    y = _float(node.get("y"))
+    size = _float(node.get("font-size"), 18)
+    width = max(1, len(text) * size * 0.58)
+    height = size * 1.25
+    return x, y - size, width, height
+
+
+def _image_box(node: ET.Element) -> tuple[float, float, float, float]:
+    return (
+        _float(node.get("x")),
+        _float(node.get("y")),
+        _float(node.get("width")),
+        _float(node.get("height")),
+    )
+
+
+def _area(box: tuple[float, float, float, float]) -> float:
+    return max(0, box[2]) * max(0, box[3])
+
+
+def _intersection(
+    a: tuple[float, float, float, float],
+    b: tuple[float, float, float, float],
+) -> float:
+    ax1, ay1, aw, ah = a
+    bx1, by1, bw, bh = b
+    ax2, ay2 = ax1 + aw, ay1 + ah
+    bx2, by2 = bx1 + bw, by1 + bh
+    w = max(0, min(ax2, bx2) - max(ax1, bx1))
+    h = max(0, min(ay2, by2) - max(ay1, by1))
+    return w * h
+
+
+def _scan_svg(svg_file: Path) -> list[dict[str, Any]]:
+    root = ET.parse(svg_file).getroot()
+    images = []
+    texts = []
+    for node in root.iter():
+        tag = node.tag.rsplit("}", 1)[-1]
+        if tag == "image":
+            images.append(_image_box(node))
+        elif tag == "text":
+            box = _text_box(node)
+            if box is not None:
+                texts.append((box, _text_content(node)))
+
+    issues = []
+    for text_box, content in texts:
+        text_area = _area(text_box)
+        if text_area <= 0:
+            continue
+        for image_box in images:
+            overlap = _intersection(text_box, image_box)
+            if overlap / text_area >= 0.25:
+                issues.append(
+                    {
+                        "text": content[:80],
+                        "text_box": [round(v, 2) for v in text_box],
+                        "image_box": [round(v, 2) for v in image_box],
+                        "overlap_ratio": round(overlap / text_area, 3),
+                    }
+                )
+    return issues
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Scan SVG pages for obvious text/image overlaps.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("project_path", help="PPT Master project directory")
+    parser.add_argument("--write-report", action="store_true", help="Write analysis/layout_safety_report.json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    project_path = Path(args.project_path)
+    svg_dir = project_path / "svg_output"
+    if not svg_dir.is_dir():
+        print(f"[ERROR] svg_output not found: {svg_dir}", file=sys.stderr)
+        return 2
+
+    report = {"ok": True, "pages": []}
+    for svg_file in sorted(svg_dir.glob("*.svg")):
+        try:
+            issues = _scan_svg(svg_file)
+        except ET.ParseError as exc:
+            issues = [{"parse_error": str(exc)}]
+        if issues:
+            report["ok"] = False
+        report["pages"].append({"file": svg_file.name, "issues": issues})
+
+    for page in report["pages"]:
+        if page["issues"]:
+            print(f"[WARN] {page['file']}: {len(page['issues'])} possible text/image overlap(s)")
+    if report["ok"]:
+        print("[OK] No obvious text/image overlaps")
+
+    if args.write_report:
+        analysis = project_path / "analysis"
+        analysis.mkdir(parents=True, exist_ok=True)
+        path = analysis / "layout_safety_report.json"
+        path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(f"Report: {path}")
+
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ppt-master/scripts/svg_to_pptx/pptx_package/builder.py
+++ b/skills/ppt-master/scripts/svg_to_pptx/pptx_package/builder.py
@@ -182,11 +182,12 @@ def _create_writable_work_dir(output_path: Path) -> Path:
             errors.append(f"{parent}: cannot create parent ({exc})")
             continue
 
-        for _ in range(3):
-            work_dir = parent / f".pptx-build-{os.getpid()}-{uuid.uuid4().hex}"
+        for attempt in range(6):
+            prefix = ".pptx-build" if attempt < 3 else "pptx-build"
+            work_dir = parent / f"{prefix}-{os.getpid()}-{uuid.uuid4().hex}"
             try:
                 work_dir.mkdir(mode=0o700)
-                probe_path = work_dir / ".write-probe"
+                probe_path = work_dir / "write-probe.txt"
                 probe_path.write_text("ok", encoding="utf-8")
                 probe_path.unlink()
                 return work_dir

--- a/skills/ppt-master/scripts/verify_beautify_fidelity.py
+++ b/skills/ppt-master/scripts/verify_beautify_fidelity.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""
+PPT Master - Beautify Text Fidelity Checker
+
+Verifies that a beautified deck preserves source slide text verbatim, page by
+page. Intended for the beautify-pptx workflow where one source slide maps to
+one output slide and no source text may be dropped or rewritten.
+
+Usage:
+    python3 scripts/verify_beautify_fidelity.py <project_path>
+    python3 scripts/verify_beautify_fidelity.py <project_path> --target-pptx exports/out.pptx
+    python3 scripts/verify_beautify_fidelity.py <project_path> --target-svg-dir svg_output
+
+Examples:
+    python3 scripts/verify_beautify_fidelity.py projects/recruitment_deck
+    python3 scripts/verify_beautify_fidelity.py projects/recruitment_deck --write-report
+
+Dependencies:
+    python-pptx (only when reading PPTX files)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree as ET
+
+from console_encoding import configure_utf8_stdio
+
+configure_utf8_stdio()
+
+SVG_NS = "http://www.w3.org/2000/svg"
+_WS_RE = re.compile(r"\s+")
+_CONTROL_RE = re.compile(r"[\u0000-\u001f\u007f]")
+_MOJIBAKE_HINT_RE = re.compile(r"[�]|(?:[\u00c0-\u00ff]{2,})|(?:[鎴涓鍙闀鏄绛寮]{2,})")
+
+
+def _norm(text: str) -> str:
+    """Normalize text for fidelity matching without changing content order."""
+    text = text.replace("\x0b", "\n")
+    text = _CONTROL_RE.sub("", text)
+    text = _WS_RE.sub("", text)
+    return text.strip()
+
+
+def _display(text: str, limit: int = 120) -> str:
+    text = _WS_RE.sub(" ", text.strip())
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+def _text_runs_from_shape_text(text: str) -> list[str]:
+    return [line.strip() for line in text.replace("\x0b", "\n").splitlines() if line.strip()]
+
+
+def _load_source_from_clean_json(project_path: Path) -> list[list[str]] | None:
+    path = project_path / "analysis" / "source_text_clean.json"
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8-sig"))
+    slides = data.get("slides", [])
+    return [
+        [
+            line
+            for block in slide.get("texts", [])
+            for line in _text_runs_from_shape_text(str(block))
+        ]
+        for slide in slides
+    ]
+
+
+def _first_source_pptx(project_path: Path) -> Path | None:
+    sources = project_path / "sources"
+    if not sources.exists():
+        return None
+    pptx_files = sorted(sources.glob("*.pptx"), key=lambda p: p.stat().st_mtime, reverse=True)
+    return pptx_files[0] if pptx_files else None
+
+
+def _load_pptx_text(path: Path) -> list[list[str]]:
+    try:
+        from pptx import Presentation
+    except ImportError as exc:
+        raise RuntimeError("python-pptx is required to read PPTX files") from exc
+
+    prs = Presentation(str(path))
+    slides: list[list[str]] = []
+    for slide in prs.slides:
+        lines: list[str] = []
+        for shape in slide.shapes:
+            if hasattr(shape, "text") and shape.text and shape.text.strip():
+                lines.extend(_text_runs_from_shape_text(shape.text))
+        slides.append(lines)
+    return slides
+
+
+def _load_source_text(project_path: Path, source_pptx: Path | None) -> tuple[list[list[str]], str]:
+    clean = _load_source_from_clean_json(project_path)
+    if clean is not None:
+        return clean, "analysis/source_text_clean.json"
+    pptx_path = source_pptx or _first_source_pptx(project_path)
+    if pptx_path is None:
+        raise FileNotFoundError(
+            "No source_text_clean.json or source PPTX found. "
+            "Run PPTX intake or pass --source-pptx."
+        )
+    return _load_pptx_text(pptx_path), str(pptx_path)
+
+
+def _load_svg_text(svg_dir: Path) -> list[list[str]]:
+    svg_files = sorted(svg_dir.glob("*.svg"))
+    pages: list[list[str]] = []
+    for svg_file in svg_files:
+        try:
+            root = ET.parse(svg_file).getroot()
+        except ET.ParseError as exc:
+            pages.append([f"__SVG_PARSE_ERROR__:{exc}"])
+            continue
+        lines: list[str] = []
+        for node in root.iter():
+            tag = node.tag.rsplit("}", 1)[-1]
+            if tag not in {"text", "tspan"}:
+                continue
+            pieces = []
+            if node.text:
+                pieces.append(node.text)
+            for child in list(node):
+                if child.text:
+                    pieces.append(child.text)
+                if child.tail:
+                    pieces.append(child.tail)
+            text = "".join(pieces).strip()
+            if text:
+                lines.append(text)
+        pages.append(lines)
+    return pages
+
+
+def _missing_items(source_lines: list[str], target_lines: list[str]) -> list[str]:
+    target_joined = _norm("".join(target_lines))
+    missing = []
+    for line in source_lines:
+        normalized = _norm(line)
+        if normalized and normalized not in target_joined:
+            missing.append(line)
+    return missing
+
+
+def _duplicate_source_lines(source_lines: list[str]) -> list[str]:
+    seen = set()
+    duplicates = []
+    for line in source_lines:
+        n = _norm(line)
+        if not n:
+            continue
+        if n in seen and line not in duplicates:
+            duplicates.append(line)
+        seen.add(n)
+    return duplicates
+
+
+def _mojibake_hits(lines: list[str]) -> list[str]:
+    return [line for line in lines if _MOJIBAKE_HINT_RE.search(line)]
+
+
+def build_report(
+    source_pages: list[list[str]],
+    target_pages: list[list[str]],
+    *,
+    source_label: str,
+    target_label: str,
+) -> dict[str, Any]:
+    page_reports = []
+    ok = True
+
+    if len(source_pages) != len(target_pages):
+        ok = False
+
+    max_pages = max(len(source_pages), len(target_pages))
+    for idx in range(max_pages):
+        source_lines = source_pages[idx] if idx < len(source_pages) else []
+        target_lines = target_pages[idx] if idx < len(target_pages) else []
+        missing = _missing_items(source_lines, target_lines)
+        mojibake = _mojibake_hits(target_lines)
+        parse_errors = [line for line in target_lines if line.startswith("__SVG_PARSE_ERROR__:")]
+        duplicates = _duplicate_source_lines(source_lines)
+        page_ok = not missing and not mojibake and not parse_errors and bool(source_lines or target_lines)
+        if not page_ok:
+            ok = False
+        page_reports.append(
+            {
+                "page": idx + 1,
+                "ok": page_ok,
+                "source_text_count": len(source_lines),
+                "target_text_count": len(target_lines),
+                "missing_count": len(missing),
+                "missing": [_display(item) for item in missing],
+                "target_mojibake_count": len(mojibake),
+                "target_mojibake": [_display(item) for item in mojibake[:10]],
+                "parse_errors": parse_errors,
+                "duplicate_source_text": [_display(item) for item in duplicates],
+            }
+        )
+
+    return {
+        "ok": ok,
+        "source": source_label,
+        "target": target_label,
+        "source_page_count": len(source_pages),
+        "target_page_count": len(target_pages),
+        "page_count_match": len(source_pages) == len(target_pages),
+        "pages": page_reports,
+    }
+
+
+def _print_summary(report: dict[str, Any]) -> None:
+    status = "OK" if report["ok"] else "FAIL"
+    print(f"[{status}] Beautify text fidelity")
+    print(f"  Source: {report['source']} ({report['source_page_count']} pages)")
+    print(f"  Target: {report['target']} ({report['target_page_count']} pages)")
+    if not report["page_count_match"]:
+        print("  [ERROR] page count mismatch")
+    for page in report["pages"]:
+        if page["ok"]:
+            continue
+        print(f"  [P{page['page']:02d}] missing={page['missing_count']} mojibake={page['target_mojibake_count']}")
+        for item in page["missing"][:8]:
+            print(f"    - missing: {item}")
+        for item in page["target_mojibake"][:4]:
+            print(f"    - mojibake: {item}")
+        for item in page["parse_errors"]:
+            print(f"    - parse: {item}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify beautify-pptx 1:1 text fidelity.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("project_path", help="PPT Master project directory")
+    parser.add_argument("--source-pptx", default=None, help="Source PPTX override")
+    parser.add_argument("--target-pptx", default=None, help="Generated PPTX to verify")
+    parser.add_argument(
+        "--target-svg-dir",
+        default="svg_output",
+        help="Generated SVG directory relative to project path (default: svg_output)",
+    )
+    parser.add_argument(
+        "--write-report",
+        action="store_true",
+        help="Write analysis/text_fidelity_report.json",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    project_path = Path(args.project_path)
+    if not project_path.is_dir():
+        print(f"[ERROR] Project not found: {project_path}", file=sys.stderr)
+        return 2
+
+    source_pptx = Path(args.source_pptx) if args.source_pptx else None
+    try:
+        source_pages, source_label = _load_source_text(project_path, source_pptx)
+        if args.target_pptx:
+            target_path = Path(args.target_pptx)
+            if not target_path.is_absolute():
+                target_path = project_path / target_path
+            target_pages = _load_pptx_text(target_path)
+            target_label = str(target_path)
+        else:
+            svg_dir = Path(args.target_svg_dir)
+            if not svg_dir.is_absolute():
+                svg_dir = project_path / svg_dir
+            target_pages = _load_svg_text(svg_dir)
+            target_label = str(svg_dir)
+    except (FileNotFoundError, RuntimeError, json.JSONDecodeError, OSError) as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 2
+
+    report = build_report(
+        source_pages,
+        target_pages,
+        source_label=source_label,
+        target_label=target_label,
+    )
+    _print_summary(report)
+
+    if args.write_report:
+        analysis_dir = project_path / "analysis"
+        analysis_dir.mkdir(parents=True, exist_ok=True)
+        report_path = analysis_dir / "text_fidelity_report.json"
+        report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(f"  Report: {report_path}")
+
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ppt-master/workflows/beautify-pptx.md
+++ b/skills/ppt-master/workflows/beautify-pptx.md
@@ -22,6 +22,8 @@ Re-lays-out an existing `.pptx`: the text is preserved **verbatim**, the source 
 
 **Hard rule — content is frozen**: every text string from the source is preserved exactly (no add / remove / reword / reorder). Beautification freedom lives only in layout, hierarchy, spacing, and visual rhythm.
 
+**Hard rule — no truncation**: beautify pages MUST NOT use line caps, summary-only cards, ellipses, or hidden overflow to make content fit. If a source slide is dense, keep the 1:1 page but solve fit with layout, columns, image size, local body-size fallback within Executor limits, or a clearly dense reference layout. A beautified page with missing source text is a failed page, even when the SVG and PPTX export technically succeed.
+
 **Hard rule — not a patch, not a fill**: this regenerates a native deck through Strategist → Executor → export (SKILL.md Steps 4–7). It does **not** edit the source file in place, and it is **not** [`template-fill-pptx`](./template-fill-pptx.md) (which clones source slides and replaces text). It also does not parse an arbitrary third-party template for text-only substitution (the rejected #53 direction) — it builds every page from scratch.
 
 **Distinct from mirror templates**: `replication_mode: mirror` (executor §1.1) keeps layout + visuals verbatim and edits text. Beautify is the inverse — content verbatim, layout redone, identity inherited.
@@ -209,6 +211,14 @@ On confirmation, enter SKILL.md Step 4 as Strategist with the plan pre-resolved.
 
 Run the standard pipeline (SKILL.md Steps 6–7). The Executor re-lays-out each page — hierarchy, spacing, alignment, page rhythm — using **only** the inherited palette + fonts from `spec_lock.md`, regenerates charts / tables as native SVG from the extracted data, and re-lays-out the source pictures.
 
+Before Step 7 post-processing, run the beautify text-fidelity gate against the authored SVGs:
+
+```bash
+python3 ${SKILL_DIR}/scripts/verify_beautify_fidelity.py <project_path> --write-report
+```
+
+Any missing text, mojibake, XML parse failure, or page-count mismatch is a blocking error. Return to Executor, fix the owning SVG page(s), and re-run the fidelity gate until it exits 0. Do not continue to `finalize_svg.py` or `svg_to_pptx.py` while this gate fails.
+
 ```bash
 python3 ${SKILL_DIR}/scripts/finalize_svg.py <project_path>
 python3 ${SKILL_DIR}/scripts/svg_to_pptx.py <project_path>
@@ -220,6 +230,8 @@ python3 ${SKILL_DIR}/scripts/svg_to_pptx.py <project_path>
 
 ```bash
 python3 ${SKILL_DIR}/scripts/source_to_md/ppt_to_md.py <project_path>/exports/<output.pptx>
+python3 ${SKILL_DIR}/scripts/verify_beautify_fidelity.py <project_path> --target-pptx <project_path>/exports/<output.pptx> --write-report
+python3 ${SKILL_DIR}/scripts/export_qa.py <project_path> --pptx <project_path>/exports/<output.pptx> --beautify
 ```
 
 | Check | Expected |


### PR DESCRIPTION
<!-- Before opening a PR, read CONTRIBUTING.md in full — especially
     "Before You Open a PR" and "AI-assisted PRs". -->

## What & why

<!-- What changed and why. For bug fixes: reproduction steps. -->

## Verification

<!-- What you ran locally and what you observed. -->

## Confirmations

<!-- All three boxes must be checked. Any unchecked box = the PR is closed without review. -->

**All three of the following must be checked. If any one is left unchecked, the PR is closed without review.**

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I personally reviewed the full diff and verified every claim in this description against this repository's actual code — including that the problem is real here and the capability isn't already provided by an existing path or already fixed on `main` (purely AI-generated PRs without human review are closed unmerged)
- [ ] This PR is code-only, **or** it touches prompt/instruction text (`SKILL.md`, `references/*.md`, `workflows/*.md`, …) and was discussed and agreed in an issue first — link it here: #___
