### PR TITLE
feat(svg_to_pptx): keep only the latest pptx at exports/ root, auto-archive older ones

### DIFF
--- a/skills/ppt-master/SKILL.md
+++ b/skills/ppt-master/SKILL.md
@@ -640,6 +640,7 @@ Default raster handling for `svg_final/`: images are embedded at the rendered SV
 python3 ${SKILL_DIR}/scripts/svg_to_pptx.py <project_path>
 # Output (default-flow mode):
 #   exports/<project_name>_<timestamp>.pptx           ← native pptx (canonical output, reads svg_output/)
+#   exports/archive/                                  ← older exports auto-moved here; exports/ root keeps only the latest
 #   backup/<timestamp>/svg_output/                    ← Executor SVG source backup (always written)
 #
 # Add --svg-snapshot to additionally emit the SVG-image preview pptx alongside the native pptx:

--- a/skills/ppt-master/scripts/docs/svg-pipeline.md
+++ b/skills/ppt-master/scripts/docs/svg-pipeline.md
@@ -45,6 +45,7 @@ python3 scripts/svg_to_pptx.py <project_path> --recorded-narration audio
 Behavior:
 - Default output (default-flow mode, no `-o`):
   - `exports/<project_name>_<timestamp>.pptx` — native editable pptx (canonical output)
+  - `exports/archive/` — after a successful export, every older pptx (and its `.trace.json` sidecar) in the `exports/` root is moved here, so the root always holds only the latest export
   - `backup/<timestamp>/svg_output/` — copy of Executor SVG source, always written so the pptx can be rebuilt via `finalize_svg → svg_to_pptx` without re-running the LLM
 - `--svg-snapshot` (opt-in) additionally emits:
   - `exports/<project_name>_<timestamp>_svg.pptx` — SVG snapshot pptx for visual reference, sibling of the native pptx

--- a/skills/ppt-master/scripts/project_manager.py
+++ b/skills/ppt-master/scripts/project_manager.py
@@ -175,7 +175,7 @@ class ProjectManager:
                 "- `live_preview/`: browser preview runtime files and history (lock.json, server.log, edits.jsonl, annotations.jsonl)\n"
                 "- `sources/`: source materials and normalized markdown\n"
                 "- `analysis/`: machine-extracted intermediate analysis (PPTX intake, image_analysis.csv) — the pipeline's canonical must-read source/asset facts\n"
-                "- `exports/`: main native pptx (timestamped); `_svg.pptx` sibling added with `--svg-snapshot`, `_native_charts.pptx` name with `--native-objects`\n"
+                "- `exports/`: latest native pptx only (timestamped); `_svg.pptx` sibling added with `--svg-snapshot`, `_native_charts.pptx` name with `--native-objects`; older exports auto-move to `exports/archive/`\n"
                 "- `backup/<timestamp>/`: svg_output/ archive (always written in default-flow mode; safe to delete old timestamps)\n"
             ),
             encoding="utf-8",

--- a/skills/ppt-master/scripts/svg_to_pptx/pptx_package/cli.py
+++ b/skills/ppt-master/scripts/svg_to_pptx/pptx_package/cli.py
@@ -71,6 +71,39 @@ def _recorded_narration_on_click_slides(
     return blocked
 
 
+def _archive_previous_exports(exports_dir: Path, keep: set[Path], verbose: bool) -> None:
+    """Move every pptx in exports/ root except `keep` (plus .trace.json sidecars) into exports/archive/.
+
+    Keeps the freshest deliverable as the only pptx directly under exports/.
+    A name collision in archive/ gets a numeric suffix; a failed move warns
+    and continues so one locked file cannot abort the sweep.
+    """
+    stale = [
+        path for path in sorted(exports_dir.glob("*.pptx"))
+        if path.is_file() and path not in keep
+    ]
+    if not stale:
+        return
+    archive_dir = exports_dir / "archive"
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    for old_pptx in stale:
+        sidecar = old_pptx.with_name(old_pptx.name + ".trace.json")
+        for src in (old_pptx, sidecar):
+            if not src.is_file():
+                continue
+            dst = archive_dir / src.name
+            counter = 1
+            while dst.exists():
+                dst = archive_dir / f"{src.stem}_{counter}{src.suffix}"
+                counter += 1
+            try:
+                shutil.move(str(src), str(dst))
+            except OSError as exc:
+                print(f"  [warn] archive move skipped for {src.name}: {exc}", file=sys.stderr)
+    if verbose:
+        print(f"  Previous export(s) archived: {len(stale)} -> {archive_dir}")
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point for the SVG to PPTX conversion tool."""
     transition_choices = (
@@ -655,6 +688,10 @@ Recorded narration:
             **shared_kwargs,
         )
         success = success and ok
+
+    if success and args.output is None:
+        keep = {path for path in (native_path, legacy_path) if path is not None}
+        _archive_previous_exports(exports_dir, keep, verbose)
 
     # svg_output/ snapshot — runs once per export in default-flow mode,
     # decoupled from --svg-snapshot. Preserves the AI-generated SVG sources


### PR DESCRIPTION
## What & why

In default-flow mode (no `-o`), every export appends another timestamped pptx to `exports/`, so after a few iterations the actual deliverable has to be picked out of a growing pile of near-identical files.

This PR keeps the `exports/` root clean: after a **successful** export, every pre-existing pptx in the `exports/` root (plus its `.trace.json` sidecar) is moved into `exports/archive/`, leaving the freshest export as the only pptx directly under `exports/`.

Behavior details:

- Runs only after the export succeeds — a failed export never disturbs the root
- Explicit `-o` output paths are user-managed and are never archived
- Same-run siblings stay together in the root (`_svg.pptx` snapshot via `--svg-snapshot`, `_native_charts.pptx` via `--native-objects`)
- Name collisions in `archive/` get a numeric suffix; a locked/unmovable file logs a warning and is skipped instead of aborting the sweep
- `template_fill_pptx`'s latest-export lookup (`exports/*.pptx` non-recursive glob) still resolves correctly — arguably more reliably, since the root now only ever contains the latest export

Implementation is a single module-level helper `_archive_previous_exports()` in `svg_to_pptx/pptx_package/cli.py` plus a two-line call site in `main()`; docs updated to match (SKILL.md Step 7.3 output listing, `scripts/docs/svg-pipeline.md`, project README template in `project_manager.py`).

## Verification

Ran on a minimal test project (single-SVG `svg_output/`), all in default-flow mode unless noted:

1. First export → `exports/proj_<ts>.pptx` created, no archive activity (nothing stale)
2. Second export → previous pptx moved to `exports/archive/`, root contains only the new export
3. `--svg-snapshot` export → both same-run files (`.pptx` + `_svg.pptx`) stay in root, prior export archived
4. `-o exports/manual.pptx` → no archiving performed, root left untouched

## Confirmations

**All three of the following must be checked. If any one is left unchecked, the PR is closed without review.**

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I personally reviewed the full diff and verified every claim in this description against this repository's actual code — including that the problem is real here and the capability isn't already provided by an existing path or already fixed on `main` (purely AI-generated PRs without human review are closed unmerged)
- [ ] This PR is code-only, **or** it touches prompt/instruction text (`SKILL.md`, `references/*.md`, `workflows/*.md`, …) and was discussed and agreed in an issue first — link it here: #___