### PR TITLE
feat(engine): self-contained engine pack for desktop embeds

### DIFF
--- a/.github/workflows/engine-pack.yml
+++ b/.github/workflows/engine-pack.yml
@@ -1,0 +1,128 @@
+# Build and publish MindMux-compatible engine packs.
+# Trigger: push tag engine-v* or workflow_dispatch.
+name: engine-pack
+
+on:
+  push:
+    tags:
+      - "engine-v*"
+  workflow_dispatch:
+    inputs:
+      upload_release:
+        description: "Create/update a GitHub release and upload zips"
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            platform: darwin
+            arch: arm64
+            python: "3.11"
+          - os: macos-13
+            platform: darwin
+            arch: x64
+            python: "3.11"
+          - os: ubuntu-22.04
+            platform: linux
+            arch: x64
+            python: "3.11"
+          - os: windows-2022
+            platform: win32
+            arch: x64
+            python: "3.11"
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install rsync (macOS runners have it; Linux ensure)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y rsync
+
+      - name: Build engine pack
+        shell: bash
+        env:
+          PYTHON: python
+          ENGINE_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || '0.1.0-dev' }}
+        run: |
+          chmod +x engine/build.sh
+          # Normalize ENGINE_VERSION tag engine-v0.1.0 → 0.1.0
+          V="${ENGINE_VERSION#engine-v}"
+          V="${V#v}"
+          export ENGINE_VERSION="$V"
+          engine/build.sh
+
+      - name: Zip pack
+        shell: bash
+        run: |
+          FOLDER="ppt-master-engine-${{ matrix.platform }}-${{ matrix.arch }}"
+          cd dist-engine
+          if [[ "${{ matrix.platform }}" == "win32" ]]; then
+            7z a -tzip "${FOLDER}.zip" "${FOLDER}"
+          else
+            zip -ry "${FOLDER}.zip" "${FOLDER}"
+          fi
+          ls -lh "${FOLDER}.zip"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pack-${{ matrix.platform }}-${{ matrix.arch }}
+          path: dist-engine/ppt-master-engine-${{ matrix.platform }}-${{ matrix.arch }}.zip
+          if-no-files-found: error
+
+  release:
+    needs: build
+    if: github.event_name == 'push' || inputs.upload_release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: pack-*
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -lah artifacts/
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_type == 'tag' && github.ref_name || format('engine-v0.1.0-dev-{0}', github.run_number) }}
+          name: ${{ github.ref_type == 'tag' && github.ref_name || format('Engine pack dev {0}', github.run_number) }}
+          draft: ${{ github.ref_type != 'tag' }}
+          files: artifacts/*.zip
+          body: |
+            Self-contained **ppt-master engine packs** for desktop embeds (MindMux).
+
+            | Asset | Platform |
+            |-------|----------|
+            | `ppt-master-engine-darwin-arm64.zip` | macOS Apple Silicon |
+            | `ppt-master-engine-darwin-x64.zip` | macOS Intel |
+            | `ppt-master-engine-linux-x64.zip` | Linux x64 |
+            | `ppt-master-engine-win32-x64.zip` | Windows x64 |
+
+            Layout after unzip:
+            ```
+            ppt-master-engine-<platform>-<arch>/
+              bin/ppt-master-engine/
+              skills/ppt-master/
+              manifest.json
+            ```
+
+            MindMux: `pnpm setup:ppt-master-engine` with
+            `downloadUrlTemplate` pointing at these assets.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/engine-pack.yml
+++ b/.github/workflows/engine-pack.yml
@@ -65,15 +65,33 @@ jobs:
           export ENGINE_VERSION="$V"
           engine/build.sh
 
-      - name: Zip pack
+      - name: Zip pack (if build.sh did not already)
         shell: bash
         run: |
           FOLDER="ppt-master-engine-${{ matrix.platform }}-${{ matrix.arch }}"
           cd dist-engine
-          if [[ "${{ matrix.platform }}" == "win32" ]]; then
+          if [[ -f "${FOLDER}.zip" ]]; then
+            echo "zip already present from build.sh"
+            ls -lh "${FOLDER}.zip"
+            exit 0
+          fi
+          if command -v 7z >/dev/null 2>&1; then
             7z a -tzip "${FOLDER}.zip" "${FOLDER}"
-          else
+          elif command -v zip >/dev/null 2>&1; then
             zip -ry "${FOLDER}.zip" "${FOLDER}"
+          elif command -v ditto >/dev/null 2>&1; then
+            ditto -c -k --keepParent "${FOLDER}" "${FOLDER}.zip"
+          else
+            python - <<PY
+          import pathlib, zipfile
+          root = pathlib.Path("${FOLDER}")
+          out = pathlib.Path("${FOLDER}.zip")
+          with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as zf:
+              for p in root.rglob("*"):
+                  if p.is_file():
+                      zf.write(p, p.as_posix())
+          print("wrote", out)
+          PY
           fi
           ls -lh "${FOLDER}.zip"
 

--- a/.github/workflows/engine-pack.yml
+++ b/.github/workflows/engine-pack.yml
@@ -26,7 +26,8 @@ jobs:
             platform: darwin
             arch: arm64
             python: "3.11"
-          - os: macos-13
+          # macos-13 retired (2025-12); use Intel image for darwin-x64
+          - os: macos-15-intel
             platform: darwin
             arch: x64
             python: "3.11"

--- a/.github/workflows/engine-pack.yml
+++ b/.github/workflows/engine-pack.yml
@@ -85,7 +85,8 @@ jobs:
 
   release:
     needs: build
-    if: github.event_name == 'push' || inputs.upload_release
+    # Publish whatever matrix legs succeeded (do not block on one OS failure).
+    if: always() && (github.event_name == 'push' || inputs.upload_release)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -93,11 +94,14 @@ jobs:
           path: artifacts
           pattern: pack-*
           merge-multiple: true
+          # continue if some matrix jobs failed and produced no artifact
+        continue-on-error: true
 
       - name: List artifacts
-        run: ls -lah artifacts/
+        run: ls -lah artifacts/ || echo "no artifacts"
 
       - name: Publish GitHub Release
+        if: hashFiles('artifacts/*.zip') != ''
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_type == 'tag' && github.ref_name || format('engine-v0.1.0-dev-{0}', github.run_number) }}

--- a/.github/workflows/engine-pack.yml
+++ b/.github/workflows/engine-pack.yml
@@ -1,25 +1,14 @@
 # Build multi-arch engine packs and publish to GitHub Releases.
 #
-# Automatic path (canonical):
-#   git tag engine-v0.1.1 && git push origin engine-v0.1.1
-#   → matrix build → non-draft release on that tag with all zips
-#
-# Manual path:
-#   workflow_dispatch with optional release_tag (e.g. engine-v0.1.0)
-#   → rebuild and upload/replace assets on that tag (published, not draft)
+# Only path: push a tag matching engine-v*
+#   git tag engine-v0.1.0 && git push origin engine-v0.1.0
+#   → matrix build → published release on that tag (all platform zips)
 name: engine-pack
 
 on:
   push:
     tags:
       - "engine-v*"
-  workflow_dispatch:
-    inputs:
-      release_tag:
-        description: "Release tag to create/update (e.g. engine-v0.1.0). Empty = no release upload."
-        type: string
-        required: false
-        default: ""
 
 permissions:
   contents: write
@@ -61,30 +50,17 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y rsync
 
-      - name: Resolve ENGINE_VERSION
-        id: ver
-        shell: bash
-        run: |
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            T="${{ github.ref_name }}"
-          elif [[ -n "${{ inputs.release_tag }}" ]]; then
-            T="${{ inputs.release_tag }}"
-          else
-            T="0.1.0-dev"
-          fi
-          V="${T#engine-v}"
-          V="${V#v}"
-          echo "engine_version=$V" >> "$GITHUB_OUTPUT"
-          echo "release_tag=${T}" >> "$GITHUB_OUTPUT"
-          echo "Using ENGINE_VERSION=$V (tag/input=$T)"
-
       - name: Build engine pack
         shell: bash
         env:
           PYTHON: python
-          ENGINE_VERSION: ${{ steps.ver.outputs.engine_version }}
+          # tag engine-v0.1.0 → 0.1.0
+          ENGINE_VERSION: ${{ github.ref_name }}
         run: |
           chmod +x engine/build.sh
+          V="${ENGINE_VERSION#engine-v}"
+          V="${V#v}"
+          export ENGINE_VERSION="$V"
           engine/build.sh
 
       - name: Ensure zip
@@ -124,13 +100,8 @@ jobs:
 
   release:
     needs: build
-    # Tag push always publishes; dispatch only when release_tag is set.
-    if: >-
-      always()
-      && (
-        github.ref_type == 'tag'
-        || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
-      )
+    # Publish whatever matrix legs produced artifacts (do not require every OS).
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -141,34 +112,22 @@ jobs:
 
       - name: List artifacts
         run: |
-          ls -lah artifacts/
-          test -n "$(ls artifacts/*.zip 2>/dev/null)" || { echo "no zips"; exit 1; }
+          ls -lah artifacts/ || true
+          test -n "$(ls artifacts/*.zip 2>/dev/null)" || { echo "no zips to publish"; exit 1; }
 
-      - name: Resolve release tag
-        id: tag
-        shell: bash
-        run: |
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            echo "name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "name=${{ inputs.release_tag }}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Publish GitHub Release (tag → assets, not draft)
+      - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.tag.outputs.name }}
-          name: ${{ steps.tag.outputs.name }}
-          # Tag-driven releases are always published (downloadable).
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           draft: false
-          # Re-running the same tag replaces/updates assets on that release.
           make_latest: false
           files: artifacts/*.zip
           fail_on_unmatched_files: true
           body: |
             Self-contained **ppt-master engine packs** for desktop embeds (e.g. MindMux).
 
-            Built automatically from tag `${{ steps.tag.outputs.name }}`.
+            Built automatically from tag `${{ github.ref_name }}`.
 
             | Asset | Platform |
             |-------|----------|
@@ -184,7 +143,7 @@ jobs:
               manifest.json
             ```
 
-            Consumer URL pattern:
-            `https://github.com/<owner>/ppt-master/releases/download/<tag>/ppt-master-engine-{platform}-{arch}.zip`
+            URL:
+            `https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/ppt-master-engine-{platform}-{arch}.zip`
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/engine-pack.yml
+++ b/.github/workflows/engine-pack.yml
@@ -1,5 +1,12 @@
-# Build and publish MindMux-compatible engine packs.
-# Trigger: push tag engine-v* or workflow_dispatch.
+# Build multi-arch engine packs and publish to GitHub Releases.
+#
+# Automatic path (canonical):
+#   git tag engine-v0.1.1 && git push origin engine-v0.1.1
+#   → matrix build → non-draft release on that tag with all zips
+#
+# Manual path:
+#   workflow_dispatch with optional release_tag (e.g. engine-v0.1.0)
+#   → rebuild and upload/replace assets on that tag (published, not draft)
 name: engine-pack
 
 on:
@@ -8,10 +15,11 @@ on:
       - "engine-v*"
   workflow_dispatch:
     inputs:
-      upload_release:
-        description: "Create/update a GitHub release and upload zips"
-        type: boolean
-        default: true
+      release_tag:
+        description: "Release tag to create/update (e.g. engine-v0.1.0). Empty = no release upload."
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: write
@@ -26,7 +34,7 @@ jobs:
             platform: darwin
             arch: arm64
             python: "3.11"
-          # macos-13 retired (2025-12); use Intel image for darwin-x64
+          # macos-13 retired (2025-12)
           - os: macos-15-intel
             platform: darwin
             arch: x64
@@ -49,30 +57,42 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
-      - name: Install rsync (macOS runners have it; Linux ensure)
+      - name: Install rsync (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y rsync
+
+      - name: Resolve ENGINE_VERSION
+        id: ver
+        shell: bash
+        run: |
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            T="${{ github.ref_name }}"
+          elif [[ -n "${{ inputs.release_tag }}" ]]; then
+            T="${{ inputs.release_tag }}"
+          else
+            T="0.1.0-dev"
+          fi
+          V="${T#engine-v}"
+          V="${V#v}"
+          echo "engine_version=$V" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${T}" >> "$GITHUB_OUTPUT"
+          echo "Using ENGINE_VERSION=$V (tag/input=$T)"
 
       - name: Build engine pack
         shell: bash
         env:
           PYTHON: python
-          ENGINE_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || '0.1.0-dev' }}
+          ENGINE_VERSION: ${{ steps.ver.outputs.engine_version }}
         run: |
           chmod +x engine/build.sh
-          # Normalize ENGINE_VERSION tag engine-v0.1.0 → 0.1.0
-          V="${ENGINE_VERSION#engine-v}"
-          V="${V#v}"
-          export ENGINE_VERSION="$V"
           engine/build.sh
 
-      - name: Zip pack (if build.sh did not already)
+      - name: Ensure zip
         shell: bash
         run: |
           FOLDER="ppt-master-engine-${{ matrix.platform }}-${{ matrix.arch }}"
           cd dist-engine
           if [[ -f "${FOLDER}.zip" ]]; then
-            echo "zip already present from build.sh"
             ls -lh "${FOLDER}.zip"
             exit 0
           fi
@@ -104,8 +124,13 @@ jobs:
 
   release:
     needs: build
-    # Publish whatever matrix legs succeeded (do not block on one OS failure).
-    if: always() && (github.event_name == 'push' || inputs.upload_release)
+    # Tag push always publishes; dispatch only when release_tag is set.
+    if: >-
+      always()
+      && (
+        github.ref_type == 'tag'
+        || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -113,22 +138,37 @@ jobs:
           path: artifacts
           pattern: pack-*
           merge-multiple: true
-          # continue if some matrix jobs failed and produced no artifact
-        continue-on-error: true
 
       - name: List artifacts
-        run: ls -lah artifacts/ || echo "no artifacts"
+        run: |
+          ls -lah artifacts/
+          test -n "$(ls artifacts/*.zip 2>/dev/null)" || { echo "no zips"; exit 1; }
 
-      - name: Publish GitHub Release
-        if: hashFiles('artifacts/*.zip') != ''
+      - name: Resolve release tag
+        id: tag
+        shell: bash
+        run: |
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            echo "name=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${{ inputs.release_tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish GitHub Release (tag → assets, not draft)
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_type == 'tag' && github.ref_name || format('engine-v0.1.0-dev-{0}', github.run_number) }}
-          name: ${{ github.ref_type == 'tag' && github.ref_name || format('Engine pack dev {0}', github.run_number) }}
-          draft: ${{ github.ref_type != 'tag' }}
+          tag_name: ${{ steps.tag.outputs.name }}
+          name: ${{ steps.tag.outputs.name }}
+          # Tag-driven releases are always published (downloadable).
+          draft: false
+          # Re-running the same tag replaces/updates assets on that release.
+          make_latest: false
           files: artifacts/*.zip
+          fail_on_unmatched_files: true
           body: |
-            Self-contained **ppt-master engine packs** for desktop embeds (MindMux).
+            Self-contained **ppt-master engine packs** for desktop embeds (e.g. MindMux).
+
+            Built automatically from tag `${{ steps.tag.outputs.name }}`.
 
             | Asset | Platform |
             |-------|----------|
@@ -137,7 +177,6 @@ jobs:
             | `ppt-master-engine-linux-x64.zip` | Linux x64 |
             | `ppt-master-engine-win32-x64.zip` | Windows x64 |
 
-            Layout after unzip:
             ```
             ppt-master-engine-<platform>-<arch>/
               bin/ppt-master-engine/
@@ -145,7 +184,7 @@ jobs:
               manifest.json
             ```
 
-            MindMux: `pnpm setup:ppt-master-engine` with
-            `downloadUrlTemplate` pointing at these assets.
+            Consumer URL pattern:
+            `https://github.com/<owner>/ppt-master/releases/download/<tag>/ppt-master-engine-{platform}-{arch}.zip`
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,7 @@ projects/*
 skills/ppt-master/templates/brands/*/exports/
 skills/ppt-master/templates/decks/*/exports/
 skills/ppt-master/templates/layouts/*/exports/
+
+# Engine pack build output
+dist-engine/
+

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,0 +1,40 @@
+# ppt-master engine pack
+
+Build a **self-contained** runtime for embedding in desktop apps (e.g. MindMux):
+
+- `bin/ppt-master-engine/` — PyInstaller launcher (bundled Python + python-pptx stack)
+- `skills/ppt-master/` — slim skill content (scripts, templates, references; no example decks / AI gallery PNGs)
+- `manifest.json` — version / platform metadata
+
+Apps invoke:
+
+```bash
+./bin/ppt-master-engine/ppt-master-engine project_manager init demo --format ppt169 --dir work
+./bin/ppt-master-engine/ppt-master-engine svg_to_pptx /path/to/project
+```
+
+## Build (local)
+
+```bash
+# Prefer Python 3.11–3.12 for PyInstaller stability
+PYTHON=python3.11 engine/build.sh
+```
+
+Output: `dist-engine/ppt-master-engine-<platform>-<arch>/`
+
+## Zip for GitHub Releases
+
+```bash
+cd dist-engine
+zip -ry "ppt-master-engine-$(uname -s | tr A-Z a-z)-$(uname -m | sed 's/x86_64/x64/;s/arm64/arm64/').zip" ppt-master-engine-*
+```
+
+CI (`.github/workflows/engine-pack.yml`) builds and uploads zip assets on tag `engine-v*`.
+
+## MindMux
+
+```bash
+# In mindmux-app:
+pnpm setup:ppt-master-engine /path/to/ppt-master-engine-darwin-arm64
+# or configure downloadUrlTemplate to this fork's Releases.
+```

--- a/engine/UPSTREAM_PR.md
+++ b/engine/UPSTREAM_PR.md
@@ -1,0 +1,49 @@
+# Upstream PR notes (hugohe3/ppt-master)
+
+## Goal
+
+Add optional **engine pack** build + CI so desktop hosts (e.g. MindMux) can ship a self-contained runtime without system Python.
+
+## Non-goals
+
+- Do not change the existing skill-only Release assets (`ppt-master-skill-v*.zip`).
+- Do not require engine packs for IDE users of the skill.
+
+## What this PR adds
+
+| Path | Purpose |
+|------|---------|
+| `engine/launcher.py` | CLI dispatcher: `ppt-master-engine <script> [args…]` |
+| `engine/build.sh` | Build onedir PyInstaller pack + slim skill tree |
+| `engine/requirements-engine.txt` | Minimal freeze deps |
+| `engine/README.md` | Build / layout docs |
+| `.github/workflows/engine-pack.yml` | Matrix build + upload on `engine-v*` tags |
+
+## Pack layout (contract)
+
+```
+ppt-master-engine-<platform>-<arch>/
+  bin/ppt-master-engine/ppt-master-engine[.exe]
+  skills/ppt-master/   # scripts, templates, references (no examples / no ai-image-comparison gallery)
+  manifest.json
+```
+
+## How to verify
+
+```bash
+PYTHON=python3.11 engine/build.sh
+./dist-engine/ppt-master-engine-*/bin/ppt-master-engine/ppt-master-engine --version
+# optional: project_manager init + svg_to_pptx smoke
+```
+
+## Suggested release process
+
+1. Merge this PR.
+2. Tag `engine-v0.1.0` (or run workflow_dispatch).
+3. Attach multi-arch zips from the workflow.
+
+## Downstream consumer (MindMux)
+
+`pnpm setup:ppt-master-engine` downloads:
+
+`https://github.com/<org>/ppt-master/releases/download/engine-vX.Y.Z/ppt-master-engine-{platform}-{arch}.zip`

--- a/engine/UPSTREAM_PR.md
+++ b/engine/UPSTREAM_PR.md
@@ -1,5 +1,9 @@
 # Upstream PR notes (hugohe3/ppt-master)
 
+## Acknowledgments
+
+Thanks to **[@hugohe3](https://github.com/hugohe3) (Hugo He)** for creating and maintaining [ppt-master](https://github.com/hugohe3/ppt-master). This engine pack only packages the existing skill runtime for desktop embeds; the product vision and core pipeline are his work.
+
 ## Goal
 
 Add optional **engine pack** build + CI so desktop hosts (e.g. MindMux) can ship a self-contained runtime without system Python.

--- a/engine/UPSTREAM_PR.md
+++ b/engine/UPSTREAM_PR.md
@@ -8,6 +8,19 @@ Thanks to **[@hugohe3](https://github.com/hugohe3) (Hugo He)** for creating and 
 
 Add optional **engine pack** build + CI so desktop hosts (e.g. MindMux) can ship a self-contained runtime without system Python.
 
+## Why
+
+ppt-master’s skill + Python pipeline already produces strong native PPTX quality. Desktop hosts want that path, but differ from IDE skill users:
+
+| Host need | Gap with skill-only releases |
+|-----------|------------------------------|
+| No system Python for end users | Skill zip assumes an existing Python + deps |
+| One-command provision | Hosts need a downloadable, versioned artifact |
+| Fixed layout + single launcher | Full git checkout / ad-hoc venv is fragile |
+| Smaller payload | Examples / full repo are unnecessary in-app |
+
+**Engine packs** freeze a minimal PyInstaller onedir runtime + slim skill tree, published on `engine-v*` tags so skill releases stay untouched. IDE users can ignore this; hosts pin a URL and unpack into app resources. We avoid vendoring the whole repo into each host app.
+
 ## Non-goals
 
 - Do not change the existing skill-only Release assets (`ppt-master-skill-v*.zip`).

--- a/engine/build.sh
+++ b/engine/build.sh
@@ -46,29 +46,32 @@ rm -rf "$STAGE" "$BUILD_DIR"
 mkdir -p "$STAGE/bin" "$STAGE/skills" "$BUILD_DIR"
 
 # ── venv + deps ─────────────────────────────────────────────
+# Do NOT `source activate` — on Windows Git Bash the path is Scripts/, not bin/,
+# and sourcing is fragile in CI. Call venv interpreters by absolute path instead.
 VENV="$BUILD_DIR/venv"
 "$PYTHON" -m venv "$VENV"
-# shellcheck disable=SC1091
-if [[ -f "$VENV/bin/activate" ]]; then
-  # Unix
-  # shellcheck source=/dev/null
-  source "$VENV/bin/activate"
-elif [[ -f "$VENV/Scripts/activate" ]]; then
-  # Windows (Git Bash)
-  # shellcheck source=/dev/null
-  source "$VENV/Scripts/activate"
+if [[ -x "$VENV/bin/python" ]]; then
+  VENV_PY="$VENV/bin/python"
+  VENV_BIN="$VENV/bin"
+elif [[ -x "$VENV/Scripts/python.exe" ]]; then
+  VENV_PY="$VENV/Scripts/python.exe"
+  VENV_BIN="$VENV/Scripts"
+elif [[ -x "$VENV/Scripts/python" ]]; then
+  VENV_PY="$VENV/Scripts/python"
+  VENV_BIN="$VENV/Scripts"
 else
-  echo "error: venv activate script not found under $VENV" >&2
+  echo "error: venv python not found under $VENV (bin/ or Scripts/)" >&2
+  ls -la "$VENV" "$VENV/bin" "$VENV/Scripts" 2>/dev/null || true
   exit 1
 fi
-python -m pip install -U pip wheel setuptools
-python -m pip install -r "$ROOT/engine/requirements-engine.txt"
-# Ensure pyinstaller is on PATH for Windows Scripts/
-export PATH="$VENV/bin:$VENV/Scripts:$PATH"
+export PATH="$VENV_BIN:$PATH"
+echo "==> venv python: $VENV_PY"
+"$VENV_PY" -m pip install -U pip wheel setuptools
+"$VENV_PY" -m pip install -r "$ROOT/engine/requirements-engine.txt"
 
 # ── PyInstaller onedir launcher ─────────────────────────────
 echo "==> PyInstaller launcher"
-pyinstaller \
+"$VENV_PY" -m PyInstaller \
   --noconfirm \
   --clean \
   --onedir \

--- a/engine/build.sh
+++ b/engine/build.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Build a MindMux-compatible ppt-master engine pack for the current platform.
+#
+# Output:
+#   dist-engine/ppt-master-engine-<platform>-<arch>/
+#     bin/ppt-master-engine/ppt-master-engine[.exe]
+#     skills/ppt-master/   (slim skill content)
+#     manifest.json
+#
+# Usage:
+#   engine/build.sh
+#   PYTHON=python3.11 engine/build.sh
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+PYTHON="${PYTHON:-python3.11}"
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+  PYTHON=python3
+fi
+
+PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$PLATFORM" in
+  darwin) PLATFORM=darwin ;;
+  linux) PLATFORM=linux ;;
+  mingw*|msys*|cygwin*) PLATFORM=win32 ;;
+esac
+
+ARCH_RAW="$(uname -m)"
+case "$ARCH_RAW" in
+  x86_64|amd64) ARCH=x64 ;;
+  arm64|aarch64) ARCH=arm64 ;;
+  *) ARCH="$ARCH_RAW" ;;
+esac
+
+FOLDER="ppt-master-engine-${PLATFORM}-${ARCH}"
+STAGE="$ROOT/dist-engine/${FOLDER}"
+BUILD_DIR="$ROOT/dist-engine/.build-${FOLDER}"
+
+echo "==> Python: $($PYTHON --version 2>&1)"
+echo "==> Target pack: $STAGE"
+
+rm -rf "$STAGE" "$BUILD_DIR"
+mkdir -p "$STAGE/bin" "$STAGE/skills" "$BUILD_DIR"
+
+# ── venv + deps ─────────────────────────────────────────────
+VENV="$BUILD_DIR/venv"
+"$PYTHON" -m venv "$VENV"
+# shellcheck disable=SC1091
+source "$VENV/bin/activate"
+python -m pip install -U pip wheel setuptools
+python -m pip install -r "$ROOT/engine/requirements-engine.txt"
+
+# ── PyInstaller onedir launcher ─────────────────────────────
+echo "==> PyInstaller launcher"
+pyinstaller \
+  --noconfirm \
+  --clean \
+  --onedir \
+  --name ppt-master-engine \
+  --distpath "$STAGE/bin" \
+  --workpath "$BUILD_DIR/pyi-work" \
+  --specpath "$BUILD_DIR" \
+  --paths "$ROOT/skills/ppt-master/scripts" \
+  --collect-submodules pptx \
+  --collect-submodules lxml \
+  --collect-submodules PIL \
+  --hidden-import pptx \
+  --hidden-import lxml \
+  --hidden-import lxml.etree \
+  --hidden-import PIL \
+  --hidden-import PIL.Image \
+  --hidden-import xlsxwriter \
+  --hidden-import filecmp \
+  --hidden-import xml.etree.ElementTree \
+  "$ROOT/engine/launcher.py"
+
+# ── slim skill content ──────────────────────────────────────
+echo "==> Copy slim skill content"
+SKILL_SRC="$ROOT/skills/ppt-master"
+SKILL_DST="$STAGE/skills/ppt-master"
+mkdir -p "$SKILL_DST"
+
+# Core files
+cp "$SKILL_SRC/SKILL.md" "$SKILL_DST/"
+cp "$SKILL_SRC/requirements.txt" "$SKILL_DST/" 2>/dev/null || true
+
+# Scripts (full — needed for dispatch)
+rsync -a --delete \
+  --exclude '__pycache__' \
+  --exclude '*.pyc' \
+  --exclude '.DS_Store' \
+  "$SKILL_SRC/scripts/" "$SKILL_DST/scripts/"
+
+# Templates (icons + charts + layouts; skip huge nothing)
+if [[ -d "$SKILL_SRC/templates" ]]; then
+  rsync -a \
+    --exclude '__pycache__' \
+    --exclude '.DS_Store' \
+    "$SKILL_SRC/templates/" "$SKILL_DST/templates/"
+fi
+
+# References without AI image comparison gallery (~43MB of PNGs)
+if [[ -d "$SKILL_SRC/references" ]]; then
+  rsync -a \
+    --exclude 'ai-image-comparison' \
+    --exclude '__pycache__' \
+    --exclude '.DS_Store' \
+    "$SKILL_SRC/references/" "$SKILL_DST/references/"
+fi
+
+if [[ -d "$SKILL_SRC/workflows" ]]; then
+  rsync -a --exclude '.DS_Store' "$SKILL_SRC/workflows/" "$SKILL_DST/workflows/"
+fi
+
+# ── manifest ────────────────────────────────────────────────
+GIT_SHA="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+BUILT_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+VERSION="${ENGINE_VERSION:-0.1.0}+${GIT_SHA}"
+
+cat >"$STAGE/manifest.json" <<EOF
+{
+  "name": "ppt-master-engine",
+  "version": "${VERSION}",
+  "platform": "${PLATFORM}",
+  "arch": "${ARCH}",
+  "builtAt": "${BUILT_AT}",
+  "gitSha": "${GIT_SHA}",
+  "skillDir": "skills/ppt-master",
+  "bin": "bin/ppt-master-engine/ppt-master-engine"
+}
+EOF
+
+# ── smoke ───────────────────────────────────────────────────
+BIN="$STAGE/bin/ppt-master-engine/ppt-master-engine"
+if [[ "$PLATFORM" == "win32" ]]; then
+  BIN="${BIN}.exe"
+fi
+chmod +x "$BIN" 2>/dev/null || true
+echo "==> Smoke: $BIN --version"
+"$BIN" --version
+
+echo "==> Pack ready: $STAGE"
+du -sh "$STAGE" "$STAGE/bin" "$STAGE/skills" || true

--- a/engine/build.sh
+++ b/engine/build.sh
@@ -179,16 +179,36 @@ chmod +x "$BIN" 2>/dev/null || true
 echo "==> Smoke: $BIN --version"
 "$BIN" --version
 
-# ── zip (prefer ditto on macOS — preserves dylib layout without dangling links) ──
+# ── zip (portable: ditto / zip / 7z / python) ───────────────
+# Windows runners often lack `zip`; GitHub Actions has 7z. Prefer tools
+# that handle macOS dylibs correctly when available.
 ZIP_OUT="$ROOT/dist-engine/${FOLDER}.zip"
 rm -f "$ZIP_OUT"
 echo "==> Zip: $ZIP_OUT"
-if command -v ditto >/dev/null 2>&1; then
-  # ditto creates a Finder-compatible zip with correct symlink handling
-  (cd "$ROOT/dist-engine" && ditto -c -k --keepParent "$FOLDER" "${FOLDER}.zip")
-else
-  (cd "$ROOT/dist-engine" && zip -ry "${FOLDER}.zip" "$FOLDER")
-fi
+(
+  cd "$ROOT/dist-engine"
+  if command -v ditto >/dev/null 2>&1; then
+    ditto -c -k --keepParent "$FOLDER" "${FOLDER}.zip"
+  elif command -v zip >/dev/null 2>&1; then
+    zip -ry "${FOLDER}.zip" "$FOLDER"
+  elif command -v 7z >/dev/null 2>&1; then
+    7z a -tzip "${FOLDER}.zip" "$FOLDER"
+  elif command -v 7za >/dev/null 2>&1; then
+    7za a -tzip "${FOLDER}.zip" "$FOLDER"
+  else
+    # Last resort: stdlib zipfile (no external tools)
+    "$VENV_PY" - <<PY
+import pathlib, zipfile
+root = pathlib.Path("$FOLDER")
+out = pathlib.Path("${FOLDER}.zip")
+with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as zf:
+    for p in root.rglob("*"):
+        if p.is_file():
+            zf.write(p, p.as_posix())
+print("wrote", out, "bytes", out.stat().st_size)
+PY
+  fi
+)
 ls -lh "$ZIP_OUT"
 
 echo "==> Pack ready: $STAGE"

--- a/engine/build.sh
+++ b/engine/build.sh
@@ -142,5 +142,17 @@ chmod +x "$BIN" 2>/dev/null || true
 echo "==> Smoke: $BIN --version"
 "$BIN" --version
 
+# ── zip (prefer ditto on macOS — preserves dylib layout without dangling links) ──
+ZIP_OUT="$ROOT/dist-engine/${FOLDER}.zip"
+rm -f "$ZIP_OUT"
+echo "==> Zip: $ZIP_OUT"
+if command -v ditto >/dev/null 2>&1; then
+  # ditto creates a Finder-compatible zip with correct symlink handling
+  (cd "$ROOT/dist-engine" && ditto -c -k --keepParent "$FOLDER" "${FOLDER}.zip")
+else
+  (cd "$ROOT/dist-engine" && zip -ry "${FOLDER}.zip" "$FOLDER")
+fi
+ls -lh "$ZIP_OUT"
+
 echo "==> Pack ready: $STAGE"
 du -sh "$STAGE" "$STAGE/bin" "$STAGE/skills" || true

--- a/engine/build.sh
+++ b/engine/build.sh
@@ -94,6 +94,38 @@ echo "==> PyInstaller launcher"
   "$ROOT/engine/launcher.py"
 
 # ── slim skill content ──────────────────────────────────────
+# copy_tree SRC/ DST/ [extra find -prune names ...]
+# Prefer rsync; fall back to cp (Windows runners have no rsync by default).
+copy_tree() {
+  local src="$1"
+  local dst="$2"
+  shift 2
+  mkdir -p "$dst"
+  if command -v rsync >/dev/null 2>&1; then
+    local args=(-a --delete --exclude '__pycache__' --exclude '*.pyc' --exclude '.DS_Store')
+    local excl
+    for excl in "$@"; do
+      args+=(--exclude "$excl")
+    done
+    rsync "${args[@]}" "$src" "$dst"
+    return
+  fi
+  # cp fallback: wipe dest contents then copy, skipping common junk + optional names
+  find "$dst" -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true
+  # Use tar pipeline when available (Git Bash / Unix) for exclude support
+  if command -v tar >/dev/null 2>&1; then
+    local tar_ex=(--exclude='__pycache__' --exclude='*.pyc' --exclude='.DS_Store')
+    local excl
+    for excl in "$@"; do
+      tar_ex+=(--exclude="$excl")
+    done
+    # src is expected to end with /
+    (cd "${src%/}" && tar cf - "${tar_ex[@]}" .) | (cd "$dst" && tar xf -)
+    return
+  fi
+  cp -R "${src%/}/." "$dst/"
+}
+
 echo "==> Copy slim skill content"
 SKILL_SRC="$ROOT/skills/ppt-master"
 SKILL_DST="$STAGE/skills/ppt-master"
@@ -104,31 +136,20 @@ cp "$SKILL_SRC/SKILL.md" "$SKILL_DST/"
 cp "$SKILL_SRC/requirements.txt" "$SKILL_DST/" 2>/dev/null || true
 
 # Scripts (full — needed for dispatch)
-rsync -a --delete \
-  --exclude '__pycache__' \
-  --exclude '*.pyc' \
-  --exclude '.DS_Store' \
-  "$SKILL_SRC/scripts/" "$SKILL_DST/scripts/"
+copy_tree "$SKILL_SRC/scripts/" "$SKILL_DST/scripts/"
 
-# Templates (icons + charts + layouts; skip huge nothing)
+# Templates (icons + charts + layouts)
 if [[ -d "$SKILL_SRC/templates" ]]; then
-  rsync -a \
-    --exclude '__pycache__' \
-    --exclude '.DS_Store' \
-    "$SKILL_SRC/templates/" "$SKILL_DST/templates/"
+  copy_tree "$SKILL_SRC/templates/" "$SKILL_DST/templates/"
 fi
 
 # References without AI image comparison gallery (~43MB of PNGs)
 if [[ -d "$SKILL_SRC/references" ]]; then
-  rsync -a \
-    --exclude 'ai-image-comparison' \
-    --exclude '__pycache__' \
-    --exclude '.DS_Store' \
-    "$SKILL_SRC/references/" "$SKILL_DST/references/"
+  copy_tree "$SKILL_SRC/references/" "$SKILL_DST/references/" "ai-image-comparison"
 fi
 
 if [[ -d "$SKILL_SRC/workflows" ]]; then
-  rsync -a --exclude '.DS_Store' "$SKILL_SRC/workflows/" "$SKILL_DST/workflows/"
+  copy_tree "$SKILL_SRC/workflows/" "$SKILL_DST/workflows/"
 fi
 
 # ── manifest ────────────────────────────────────────────────

--- a/engine/build.sh
+++ b/engine/build.sh
@@ -49,9 +49,22 @@ mkdir -p "$STAGE/bin" "$STAGE/skills" "$BUILD_DIR"
 VENV="$BUILD_DIR/venv"
 "$PYTHON" -m venv "$VENV"
 # shellcheck disable=SC1091
-source "$VENV/bin/activate"
+if [[ -f "$VENV/bin/activate" ]]; then
+  # Unix
+  # shellcheck source=/dev/null
+  source "$VENV/bin/activate"
+elif [[ -f "$VENV/Scripts/activate" ]]; then
+  # Windows (Git Bash)
+  # shellcheck source=/dev/null
+  source "$VENV/Scripts/activate"
+else
+  echo "error: venv activate script not found under $VENV" >&2
+  exit 1
+fi
 python -m pip install -U pip wheel setuptools
 python -m pip install -r "$ROOT/engine/requirements-engine.txt"
+# Ensure pyinstaller is on PATH for Windows Scripts/
+export PATH="$VENV/bin:$VENV/Scripts:$PATH"
 
 # ── PyInstaller onedir launcher ─────────────────────────────
 echo "==> PyInstaller launcher"
@@ -135,7 +148,7 @@ EOF
 
 # ── smoke ───────────────────────────────────────────────────
 BIN="$STAGE/bin/ppt-master-engine/ppt-master-engine"
-if [[ "$PLATFORM" == "win32" ]]; then
+if [[ -f "${BIN}.exe" ]]; then
   BIN="${BIN}.exe"
 fi
 chmod +x "$BIN" 2>/dev/null || true

--- a/engine/launcher.py
+++ b/engine/launcher.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""ppt-master-engine — dispatch CLI for bundled skill scripts.
+
+Usage:
+    ppt-master-engine --version
+    ppt-master-engine <script_stem> [args...]
+
+Examples:
+    ppt-master-engine project_manager init demo --format ppt169 --dir work
+    ppt-master-engine svg_to_pptx /path/to/project
+    ppt-master-engine svg_quality_checker /path/to/project
+
+The binary lives at:
+    <pack>/bin/ppt-master-engine/ppt-master-engine
+Skill scripts live at:
+    <pack>/skills/ppt-master/scripts/
+"""
+
+from __future__ import annotations
+
+# Pre-import stdlib modules that skill scripts use but the launcher does not.
+# PyInstaller only freezes imports reachable from this entry — without this
+# list, runpy-loaded scripts fail with ModuleNotFoundError on stdlib names.
+import argparse  # noqa: F401
+import base64  # noqa: F401
+import copy  # noqa: F401
+import csv  # noqa: F401
+import dataclasses  # noqa: F401
+import datetime  # noqa: F401
+import filecmp  # noqa: F401
+import fnmatch  # noqa: F401
+import functools  # noqa: F401
+import glob  # noqa: F401
+import hashlib  # noqa: F401
+import html  # noqa: F401
+import http  # noqa: F401
+import http.client  # noqa: F401
+import http.server  # noqa: F401
+import io  # noqa: F401
+import json  # noqa: F401
+import logging  # noqa: F401
+import mimetypes  # noqa: F401
+import os  # noqa: F401
+import pathlib  # noqa: F401
+import pickle  # noqa: F401
+import platform  # noqa: F401
+import queue  # noqa: F401
+import random  # noqa: F401
+import re  # noqa: F401
+import runpy
+import shutil  # noqa: F401
+import signal  # noqa: F401
+import socket  # noqa: F401
+import sqlite3  # noqa: F401
+import ssl  # noqa: F401
+import string  # noqa: F401
+import struct  # noqa: F401
+import subprocess  # noqa: F401
+import sys
+import tempfile  # noqa: F401
+import textwrap  # noqa: F401
+import threading  # noqa: F401
+import time  # noqa: F401
+import traceback  # noqa: F401
+import typing  # noqa: F401
+import urllib  # noqa: F401
+import urllib.error  # noqa: F401
+import urllib.parse  # noqa: F401
+import urllib.request  # noqa: F401
+import uuid  # noqa: F401
+import wave  # noqa: F401
+import xml  # noqa: F401
+import xml.etree.ElementTree  # noqa: F401
+import zipfile  # noqa: F401
+from pathlib import Path
+
+ENGINE_VERSION = "0.1.0"
+
+# Short names → script file under skills/ppt-master/scripts/
+# (stem only; .py added)
+ALIASES = {
+    "project_manager": "project_manager.py",
+    "svg_to_pptx": "svg_to_pptx.py",
+    "svg_quality_checker": "svg_quality_checker.py",
+    "finalize_svg": "finalize_svg.py",
+    "total_md_split": "total_md_split.py",
+    "source_to_md": "source_to_md.py",
+    "icon_sync": "icon_sync.py",
+    "analyze_images": "analyze_images.py",
+    "image_gen": "image_gen.py",
+    "image_search": "image_search.py",
+    "animation_config": "animation_config.py",
+    "pptx_intake": "pptx_intake.py",
+    "notes_to_audio": "notes_to_audio.py",
+}
+
+
+def pack_root() -> Path:
+    """Return the engine pack root (parent of bin/ and skills/)."""
+    if getattr(sys, "frozen", False):
+        # <pack>/bin/ppt-master-engine/ppt-master-engine
+        return Path(sys.executable).resolve().parent.parent.parent
+    # Dev: engine/launcher.py → repo root is parent of engine/
+    return Path(__file__).resolve().parent.parent
+
+
+def scripts_dir(root: Path) -> Path:
+    return root / "skills" / "ppt-master" / "scripts"
+
+
+def resolve_script(name: str, sdir: Path) -> Path:
+    key = name
+    if key.endswith(".py"):
+        key = key[: -len(".py")]
+    # strip path-like prefixes
+    key = Path(key).name
+    if key.endswith(".py"):
+        key = key[: -len(".py")]
+
+    filename = ALIASES.get(key, f"{key}.py")
+    path = sdir / filename
+    if not path.is_file():
+        # also allow nested like source_to_md (dispatcher)
+        nested = sdir / key
+        if nested.is_dir() and (nested / "__main__.py").is_file():
+            return nested / "__main__.py"
+        if nested.is_file():
+            return nested
+        raise FileNotFoundError(
+            f"unknown engine command {name!r}; expected under {sdir} "
+            f"(known: {', '.join(sorted(ALIASES))})"
+        )
+    return path
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv or argv[0] in {"-h", "--help", "help"}:
+        print(__doc__.strip(), file=sys.stderr)
+        return 0 if argv and argv[0] in {"-h", "--help", "help"} else 2
+    if argv[0] in {"-V", "--version", "version"}:
+        print(f"ppt-master-engine {ENGINE_VERSION}")
+        return 0
+
+    root = pack_root()
+    sdir = scripts_dir(root)
+    if not sdir.is_dir():
+        print(
+            f"error: skill scripts not found at {sdir}\n"
+            f"  pack root resolved to: {root}",
+            file=sys.stderr,
+        )
+        return 1
+
+    cmd = argv[0]
+    rest = argv[1:]
+    try:
+        script = resolve_script(cmd, sdir)
+    except FileNotFoundError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    # Scripts expect to import siblings from the scripts directory.
+    scripts_path = str(sdir)
+    if scripts_path not in sys.path:
+        sys.path.insert(0, scripts_path)
+
+    # Emulate `python script.py args...`
+    sys.argv = [str(script), *rest]
+    try:
+        runpy.run_path(str(script), run_name="__main__")
+    except SystemExit as e:
+        code = e.code
+        if code is None:
+            return 0
+        if isinstance(code, int):
+            return code
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/engine/requirements-engine.txt
+++ b/engine/requirements-engine.txt
@@ -1,0 +1,6 @@
+# Minimal runtime deps for the MindMux / App engine pack (no TTS / genai extras).
+python-pptx>=0.6.21
+XlsxWriter>=3.0.0
+lxml>=4.9.0
+Pillow>=10.0.0
+pyinstaller>=6.0.0


### PR DESCRIPTION
## Summary

Adds an optional **engine pack** build (PyInstaller launcher + slim skill tree) and CI so desktop hosts can ship ppt-master without system Python.

This does **not** change the existing skill-only Release assets (`ppt-master-skill-v*.zip`) or the IDE skill workflow.

## Acknowledgments

Huge thanks to **[@hugohe3](https://github.com/hugohe3) (Hugo He)** for creating and maintaining [ppt-master](https://github.com/hugohe3/ppt-master)—the design system, SVG→PPTX pipeline, skills, and examples this pack simply packages for app embeds. This PR is an integration path for hosts like MindMux; the product vision and core implementation remain yours.

## Why (motivation)

ppt-master already delivers excellent native PPTX quality via skills + Python scripts. Downstream **desktop apps** (e.g. MindMux) want that quality path, but their constraints differ from IDE / Claude skill users:

| Constraint | Why skill-only release is not enough |
|------------|--------------------------------------|
| No system Python | End users / teammates should not install Python, venv, or pip deps |
| Zero-friction setup | `pnpm install` / one setup command should provision a working runtime |
| Stable contract | Hosts need a fixed on-disk layout + a single launcher binary, not a full git checkout |
| Ship size | Apps need a **slim** skill tree (scripts/templates/references), not examples or full repo |

Today, official Releases publish **skill zips only**. That is perfect for IDE agents that already have a Python environment, but desktop hosts cannot auto-download “skill markdown + scripts” and run them without also bundling an interpreter and dependencies.

**What this PR does instead:** optional, separate **engine packs** that freeze a minimal runtime:

```
ppt-master-engine-<platform>-<arch>/
  bin/ppt-master-engine/   # PyInstaller onedir launcher (no system Python)
  skills/ppt-master/       # slim skill tree used by the scripts
  manifest.json
```

- Tagged as `engine-v*` so skill releases stay independent.
- IDE / skill-only users can ignore this entirely.
- Hosts pin a versioned URL and unpack into app resources.

We intentionally **do not** vendor the whole ppt-master repo into host apps: packs stay rebuildable from upstream, versioned, and multi-arch via CI.

## Changes

- `engine/launcher.py` — CLI: `ppt-master-engine <script> [args…]`
- `engine/build.sh` — build pack for current platform
- `engine/requirements-engine.txt` — minimal freeze deps
- `.github/workflows/engine-pack.yml` — matrix build + release on `engine-v*` tags
- `engine/README.md`, `engine/UPSTREAM_PR.md`

## Test plan

- [x] Local: `PYTHON=python3.11 engine/build.sh` → `--version` OK
- [x] Local: `project_manager init` + `svg_to_pptx` smoke → native pptx
- [x] Pack consumed by MindMux `pnpm setup:ppt-master-engine` from fork Release
- [x] CI matrix green after merge (multi-arch)

## Notes for maintainers

Tagging `engine-v*` publishes multi-arch zips. IDE skill releases can stay independent. Engine packs are additive; reject or defer this PR without affecting the existing skill workflow.