### PR TITLE
fix(confirm-ui): switch UI fonts by locale

### DIFF
--- a/skills/ppt-master/scripts/confirm_ui/static/style.css
+++ b/skills/ppt-master/scripts/confirm_ui/static/style.css
@@ -15,21 +15,38 @@
     --warning: #f5c542;
     --radius: 10px;
     --shadow: 0 4px 24px rgba(0, 0, 0, 0.22);
+    --ui-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
 }
 
 * { box-sizing: border-box; }
 
 html { height: 100%; }
 
+html:lang(ja) {
+    --ui-font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic UI",
+        "Yu Gothic", "Meiryo UI", Meiryo, "Noto Sans CJK JP", "Noto Sans JP", sans-serif;
+}
+
+html:lang(zh) {
+    --ui-font-family: "PingFang SC", "Microsoft YaHei UI", "Microsoft YaHei",
+        "Noto Sans CJK SC", "Noto Sans SC", "Hiragino Sans GB", sans-serif;
+}
+
 body {
     margin: 0;
     height: 100%;
     background: #1a1a2e;
     color: var(--ink);
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Microsoft YaHei",
-        "PingFang SC", "Hiragino Sans GB", sans-serif;
+    font-family: var(--ui-font-family);
     line-height: 1.5;
     overflow: hidden;
+}
+
+button,
+input,
+select,
+textarea {
+    font-family: inherit;
 }
 
 /* ---- fullscreen shell ---- */


### PR DESCRIPTION
## Summary

The Confirm UI previously used a single hard-coded body font stack that listed Chinese fonts (Microsoft YaHei, PingFang SC, Hiragino Sans GB) for every UI language, so Japanese UI text was rendered with Chinese glyph forms. This change makes the UI font follow the active UI language:

- Adds a `--ui-font-family` custom property with a neutral system stack as the English default.
- Overrides it via `html:lang(ja)` with a Japanese stack (Hiragino Sans, Yu Gothic, Meiryo, Noto Sans JP fallbacks) and via `html:lang(zh)` with a Chinese stack (PingFang SC, Microsoft YaHei, Noto Sans SC fallbacks).
- Applies the property on `body` and adds `font-family: inherit` to `button`, `input`, `select`, and `textarea` so form controls follow the same stack.

Because `app.js` already sets the `<html lang>` attribute (`ja` / `zh-CN` / `en`) at startup and whenever the language menu changes, the font switches immediately with a CSS-only change — no JS modifications. `:lang(zh)` matches `zh-CN` via language-range matching.

Deck typography candidate previews with configured font stacks are unaffected: they apply their candidate families inline, which overrides the inherited UI font. The one behavioral nuance is that a candidate with an *empty* stack (where `app.js` sets no inline family) now inherits the locale-appropriate UI font instead of the old fixed mixed-CJK stack — a natural fallback rather than a regression.

Scope: one file, `skills/ppt-master/scripts/confirm_ui/static/style.css`.

## Testing

- `git diff --check` — clean.
- Manual verification: started the Confirm UI server locally against a Stage 1 Japanese recommendation and drove it with Playwright, switching the language menu ja → zh-CN → en → ja; `getComputedStyle` on `body`, the language toggle button, and the confirm button returned the matching stack for each language, with translated titles rendering correctly (e.g., "PPT Master - デザイン確認" for ja). The only console error was a pre-existing, unrelated `favicon.ico` 404.
- The no-mistakes gate passed end to end (review, tests, lint, docs). Its browser checks independently exercised the real Confirm UI server with Playwright/Chrome across en, ja, and zh, verified body and form-control computed font-family values, compared the Japanese page against the base CSS, and ran a Stage 2 typography preview check — all passed. The gate's review surfaced only the informational empty-stack fallback note described above; no fix was required.
