### PR TITLE
fix(confirm-ui): prevent unreachable-confirm state on custom colour card

### DIFF
--- a/skills/ppt-master/scripts/confirm_ui/static/app.js
+++ b/skills/ppt-master/scripts/confirm_ui/static/app.js
@@ -1704,6 +1704,18 @@
         }
 
         function selectCustomColor() {
+            // Seed the free-text box from the palette currently on screen. Choosing
+            // Custom with an empty box stored \palette: {}\ together with \custom: ""\,
+            // which fails both branches of designSystemValid and blocks Continue while
+            // the card still looks selected.
+            if (!String(customInput.value || "").trim()) {
+                var seed = (STATE.color && STATE.color.palette) || {};
+                var seeded = PALETTE_ROLES.map(function (role) {
+                    var hex = normHex(seed[role]);
+                    return hex ? role + ": " + hex : null;
+                }).filter(Boolean);
+                if (seeded.length) customInput.value = seeded.join(", ");
+            }
             selectedIdx = -1;
             STATE.color = { name: "custom", custom: customInput.value || "", palette: {} };
             grid.querySelectorAll(".color-card").forEach(function (card) { card.classList.remove("selected"); });
@@ -2872,7 +2884,14 @@
         var valid = (completePalette || customPalette) &&
             completeFamilies && completeSizes;
         if (!valid) {
-            document.getElementById("confirm-status").textContent = t("design_system_required");
+            // Name the failing condition — the generic sentence alone left users
+            // guessing which of the three requirements was unmet.
+            var missing = [];
+            if (!(completePalette || customPalette)) missing.push("palette");
+            if (!(completeFamilies || customFamilies)) missing.push("typography");
+            if (!completeSizes) missing.push("sizes");
+            document.getElementById("confirm-status").textContent =
+                t("design_system_required") + " [" + missing.join(", ") + "]";
         }
         return !!valid;
     }


### PR DESCRIPTION
## Problem

Selecting the **Custom** colour card in the Stage-2 confirm page can put the page into a state where **Continue** is permanently blocked, with no indication of what is missing.

`selectCustomColor()` stores:

```js
STATE.color = { name: "custom", custom: customInput.value || "", palette: {} };
```

When the free-text box is still empty at that moment, this yields `palette: {}` **and** `custom: ""`. In `designSystemValid()` both branches of the colour check then fail:

```js
var completePalette = PALETTE_ROLES.every(role => !!normHex(palette[role]));   // false — palette is {}
var customPalette   = color.name === "custom" && String(color.custom||"").trim(); // false — custom is ""
```

The card still renders as selected, so the state is not visible to the user, and the message names none of the three checked conditions:

> Choose a complete palette and typography system before continuing.

There are two further ways into the same message — a half-typed HEX in a role override (the intermediate value is not a valid colour) and an unset role size — and the message does not distinguish them either.

## Change

Two small edits in `static/app.js`:

1. **`selectCustomColor()` seeds the free-text box** from the palette currently on screen, so the empty-and-therefore-invalid state cannot occur. A user who wants their own description simply overwrites the seeded values.
2. **The validation message names the failing group** — `[palette]`, `[typography]` or `[sizes]` — instead of only stating that something is missing. No new i18n keys, so no translation gaps.

## Verification

Reproduced and verified in Chromium against a throwaway project.

The predicate was first exercised directly against five states to confirm the diagnosis:

| State | `completePalette` | `customPalette` | Result |
|---|---|---|---|
| Card selected | ✓ | – | valid |
| **Custom, box empty** | ✗ | ✗ | **blocked** |
| Custom with text | ✗ | ✓ | valid |
| Half-typed HEX | ✗ | ✗ | blocked |
| Missing role size | ✓ | – | blocked |

After the change:

- Clicking **Custom** fills the box with the visible palette, e.g. `background: #111827, secondary_bg: #1B2735, primary: #03B4CC, …` — the invalid state is no longer reachable.
- Clearing a role size now reports `Choose a complete palette and typography system before continuing. [sizes]` and correctly keeps the submit blocked.

`node --check` passes on the modified file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
