### PR TITLE
fix(typography): recognize Traditional Chinese system fonts as PPT-safe

### DIFF
--- a/skills/ppt-master/scripts/svg_to_pptx/drawingml/utils.py
+++ b/skills/ppt-master/scripts/svg_to_pptx/drawingml/utils.py
@@ -88,6 +88,8 @@ FONT_FALLBACK_WIN = {
     'PingFang SC': 'Microsoft YaHei',
     'PingFang TC': 'Microsoft JhengHei',
     'PingFang HK': 'Microsoft JhengHei',
+    'Heiti TC': 'Microsoft JhengHei',
+    'Kaiti TC': 'DFKai-SB',
     'Hiragino Sans': 'Microsoft YaHei',
     'Hiragino Sans GB': 'Microsoft YaHei',
     'Hiragino Mincho ProN': 'SimSun',
@@ -98,12 +100,12 @@ FONT_FALLBACK_WIN = {
     'STXihei': 'Microsoft YaHei',
     'STZhongsong': 'SimSun',
     'Songti SC': 'SimSun',
-    'Songti TC': 'SimSun',
+    'Songti TC': 'PMingLiU',
     'Noto Sans SC': 'Microsoft YaHei',
     'Noto Sans CJK SC': 'Microsoft YaHei',
     'Noto Sans TC': 'Microsoft JhengHei',
     'Noto Serif SC': 'SimSun',
-    'Noto Serif TC': 'SimSun',
+    'Noto Serif TC': 'PMingLiU',
     # Japanese: keep as-is if user specified (PowerPoint will fallback if uninstalled)
     # 'Noto Sans JP': → keep as 'Noto Sans JP' (do not map)
     # 'メイリオ': → keep as 'メイリオ' (Meiryo alias)
@@ -111,7 +113,7 @@ FONT_FALLBACK_WIN = {
     'Source Han Sans SC': 'Microsoft YaHei',
     'Source Han Sans TC': 'Microsoft JhengHei',
     'Source Han Serif SC': 'SimSun',
-    'Source Han Serif TC': 'SimSun',
+    'Source Han Serif TC': 'PMingLiU',
     'Source Han Sans JP': 'Noto Sans JP',
     'Source Han Serif JP': 'Noto Serif JP',
     'WenQuanYi Micro Hei': 'Microsoft YaHei',
@@ -153,8 +155,11 @@ _SERIF_LATIN = {
 # target-specific; keep these examples aligned with strategist.md §g.
 PPT_SAFE_FONTS = frozenset({
     'microsoft yahei', 'simhei', 'simsun', 'kaiti', 'fangsong',
-    'dengxian', 'microsoft jhenghei',
+    'dengxian',
+    'microsoft jhenghei', 'microsoft jhenghei ui', 'pmingliu', 'mingliu',
+    'mingliu_hkscs', 'dfkai-sb',
     'pingfang sc', 'heiti sc', 'songti sc', 'stsong',
+    'pingfang tc', 'pingfang hk', 'heiti tc', 'songti tc', 'kaiti tc',
     'yu gothic', 'yu gothic ui', 'yu mincho',
     'meiryo', 'meiryo ui',
     'ms gothic', 'ms mincho', 'ms pgothic', 'ms pmincho', 'ms ui gothic',


### PR DESCRIPTION
## Problem

`PPT_SAFE_FONTS` in `svg_to_pptx/drawingml/utils.py` covers the stock Simplified Chinese (YaHei/SimSun/DengXian + macOS PingFang SC/Songti SC…), Japanese, and Korean families, but Traditional Chinese only has `microsoft jhenghei`. As a result:

- A deck that uses **PMingLiU** (the standard Windows TC serif, shipped since Windows XP) emits `Font stack exports non-PPT-safe typeface(s)` on **every page** — in a real 18-slide TC deck that is 18 warnings drowning out actionable ones.
- The confirm-UI font catalog itself offers PMingLiU / MingLiU / MingLiU_HKSCS / DFKai-SB as picker options, so the pipeline warns about fonts it recommended.
- `pptx_delivery_check.py` already special-cases `pmingliu` into `_PPT_DELIVERY_SAFE_FONTS`, confirming the face is considered deliverable — the source list just never caught up.

Additionally, `FONT_FALLBACK_WIN` maps the TC serif faces (`Songti TC`, `Noto Serif TC`, `Source Han Serif TC`) to **SimSun**, which renders Traditional text with Simplified-convention glyph forms. The correct Windows target for TC serif is PMingLiU.

## Change

- `PPT_SAFE_FONTS`: add Windows TC faces (`microsoft jhenghei ui`, `pmingliu`, `mingliu`, `mingliu_hkscs`, `dfkai-sb`) and macOS TC faces (`pingfang tc`, `pingfang hk`, `heiti tc`, `songti tc`, `kaiti tc`), mirroring the existing SC coverage on both platforms.
- `FONT_FALLBACK_WIN`: retarget `Songti TC` / `Noto Serif TC` / `Source Han Serif TC` to `PMingLiU`; add missing macOS mappings `Heiti TC → Microsoft JhengHei` and `Kaiti TC → DFKai-SB`.

## Verification

On an 18-slide Traditional Chinese deck using `Microsoft JhengHei` + `PMingLiU`:
- before: 18 × `non-PPT-safe typeface (ea=PMingLiU)` warnings from `svg_quality_checker.py` and a postflight `unsafe_exported_font_faces` warning;
- after: zero font warnings, `[POSTFLIGHT] status=passed`; exported theme fonts verify as `PMingLiU` (major) / `Microsoft JhengHei` (minor).

No behavior change for SC/JP/KR decks: additions are new set entries and TC-only mapping rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)