### PR TITLE
feat(executor): five-page lightweight spec_lock re-read for Default Generate

### DIFF
--- a/skills/ppt-master/references/executor-base.md
+++ b/skills/ppt-master/references/executor-base.md
@@ -49,7 +49,7 @@ Before the first SVG page, output a confirmation listing: the compact communicat
 
 ### 2.1 Execution context validity (Mandatory)
 
-- **Valid**: if the exact complete Design Spec and lock remain in the unchanged, uncompacted active context, reuse both for every page. Do not reread or poll them.
+- **Valid**: if the exact complete Design Spec and lock remain in the unchanged, uncompacted active context, reuse both for every page. Do not reread or poll them. The one scheduled exception is the five-page lightweight lock re-read defined below.
 - **Invalid**: fresh/resumed/restarted execution, compaction/summary-only recovery, or an external/unknown change requires one complete read of `design_spec.md`, then `spec_lock.md`, plus triggered references/template inputs. Mid-deck recovery also reads the latest completed SVG and, when images are used, current image metadata.
 - **Uncertain**: consult the retained lock first, then only the owning Design Spec fragment; use sources only for facts. Design Spec remains upstream on conflict.
 
@@ -111,6 +111,16 @@ Apply the content-vs-expression contract above within the selected reading mode.
 - Formula PNGs are images with `Acquire Via: formula`; place a `Rendered` file only from its listed path, use the normal placeholder for `Needs-Manual`, and never recreate the formula as text.
 
 Return upstream before any derived/accent identity becomes recurring or structural, or when an undeclared display size reaches its third occurrence, then update the retained context under §2.1. Local garnish, same-role `±2`px adjustments, and at most two sparse display-size occurrences need no lock row. Never expand the lock to silence a comparison. New icon acquisition, images, structural fonts, role anchors, and resources keep their preparation/role rules.
+
+**Five-page lightweight lock re-read (Default Generate only)**: after
+completing P05, P10, P15, … and only when another page follows, read
+`spec_lock.md` in full once before starting the next page. This is a pure
+context re-anchor for the locked palette, typography, icon style, and
+`page_rhythm` values under long context. No checker runs, no per-page
+self-check output, no pause, and no mid-deck repair loop; generation
+continues directly after the re-read. Compaction, resume, or restart still
+follows the full recovery reads above. Quick Generate has no project root
+`spec_lock.md` and does not use this rule.
 
 **Per-page layout rhythm — `page_rhythm` section**:
 

--- a/skills/ppt-master/workflows/generate-pptx.md
+++ b/skills/ppt-master/workflows/generate-pptx.md
@@ -511,6 +511,9 @@ Workflow:
 
 **Planning context**: follow [`executor-base.md`](../references/executor-base.md) §2.1. Reuse the complete Design Spec and lock in an unchanged, uncompacted context. Fresh/resumed/restarted, compacted/summary-only, or externally/unknown changed execution reads both once and reloads triggered inputs. For a local question, consult the retained lock first, then only the owning Design Spec fragment; do not poll files merely to prove validity.
 
+**Scheduled lock re-read (Default Generate only)**: after P05, P10, P15, …,
+re-read `spec_lock.md` once before the next page per [`executor-base.md`](../references/executor-base.md) §2.1.
+
 **Artifact ownership**: `svg_output/` is the author source, `svg_final/` is derived, and image facts come from the regenerated `analysis/image_analysis.csv`; see [`references/artifact-ownership.md`](../references/artifact-ownership.md).
 
 Read the execution references for this deck's locked `mode` + `visual_style`

--- a/skills/ppt-master/workflows/generate-pptx.md
+++ b/skills/ppt-master/workflows/generate-pptx.md
@@ -511,8 +511,7 @@ Workflow:
 
 **Planning context**: follow [`executor-base.md`](../references/executor-base.md) §2.1. Reuse the complete Design Spec and lock in an unchanged, uncompacted context. Fresh/resumed/restarted, compacted/summary-only, or externally/unknown changed execution reads both once and reloads triggered inputs. For a local question, consult the retained lock first, then only the owning Design Spec fragment; do not poll files merely to prove validity.
 
-**Scheduled lock re-read (Default Generate only)**: after P05, P10, P15, …,
-re-read `spec_lock.md` once before the next page per [`executor-base.md`](../references/executor-base.md) §2.1.
+**Scheduled lock re-read (Default Generate only)**: re-read `spec_lock.md` once after P05/P10/P15/… per [`executor-base.md`](../references/executor-base.md) §2.1.
 
 **Artifact ownership**: `svg_output/` is the author source, `svg_final/` is derived, and image facts come from the regenerated `analysis/image_analysis.csv`; see [`references/artifact-ownership.md`](../references/artifact-ownership.md).
 


### PR DESCRIPTION
## Summary

Per maintainer scope agreed in #254: implement the **five-page lightweight Spec Lock re-read** for **Default Generate only**.

## Changes (2 files, prompt-only)

1. **`references/executor-base.md` §2.1** — added the scheduled exception to the owning "valid context does not re-read" rule, plus the new rule:
   - After completing P05, P10, P15, … and only when another page follows, read `spec_lock.md` in full once before starting the next page
   - Pure context re-anchor (palette / typography / icon style / page_rhythm)
   - No checker run, no per-page self-check output, no pause, no mid-deck repair loop
   - Compaction / resume / restart still use the full recovery reads
   - Quick Generate has no project root `spec_lock.md` and does not use this rule

2. **`workflows/generate-pptx.md`** — one-line sync pointing to §2.1.

## Scope exclusions (as agreed)

- ❌ No per-page self-check
- ❌ No P2 icon-coverage checker
- ❌ No Visual Review opt-in change
- ✅ Existing P01 first-page gate and final quality gate unchanged; no new mid-deck gate

## Validation

- `prompt_audit.py`: all route budgets PASS; no new audit findings (the 3 pre-existing baseline errors — corpus budget and two load-set limits — are unchanged from before this PR)
- Diff is strictly additive to the two prompt files