### PR TITLE
skill: 增加中文触发词与运行时环境发现说明（纯增量）

### DIFF
--- a/skills/ppt-master/SKILL.md
+++ b/skills/ppt-master/SKILL.md
@@ -6,7 +6,9 @@ description: >
   workspaces, filling native PPTX templates, and enhancing finished PPTX files.
   Use when the user asks to create, reconstruct, regenerate, template, fill, or
   enhance a presentation, requests a presentation-authored narrated/self-running
-  video, or mentions ppt-master.
+  video, or mentions ppt-master. 中文触发：制作/生成/美化 PPT、做幻灯片/演示
+  文稿/课件、PPT 模板填充、PPTX 转图重绘、给 PPT 加配音/动画——用户用中文提出
+  上述任一意图时同样应加载本技能。
 metadata:
   version: "4.7.0"
   copyright: "Copyright (c) 2025-2026 Hugo He"
@@ -84,3 +86,25 @@ never compete with it.
 - Repository-level documents may point into the package; package runtime files must not depend on repository-level instructions.
 - On Windows, if a documented `python3 ...` command is unavailable, rerun the same command with `python`.
 - Sponsor information is optional reference material. Read the matching [`SPONSORS.md`](SPONSORS.md) or [`SPONSORS_CN.md`](SPONSORS_CN.md) only when the user explicitly requests a model, AI image model, API/provider, or hosted-service recommendation. Never surface sponsor or model recommendations proactively during normal generation, troubleshooting, or quality review.
+
+## Runtime Environment Discovery (DSH / agent harness)
+
+The instructions above assume scripts run from this Skill directory, but an
+agent may load this file without knowing where the skill lives on disk. Before
+running any `scripts/` command, locate the skill root:
+
+1. Find the absolute path of `attribution_guard.py` under `scripts/` (use the
+   agent's file-search/glob tool if available), then derive the skill root as
+   its parent's parent. Example found roots: `~/.dsh/skills/ppt-master`,
+   `~/.claude/skills/ppt-master`, `~/.agents/skills/ppt-master`.
+2. Run every documented command from that skill root, with an absolute or
+   explicitly `cd`-anchored working directory. Never rely on CWD guesses.
+3. Python launcher resolution (Windows): try `python` first when the system
+   only exposes it; fall back to `py -3` when neither `python3` nor `python`
+   resolves. Prefer the interpreter that already carries the skill's
+   `requirements.txt` dependencies (`python -c "import pptx"` is a quick probe).
+
+This section is a location/launcher shim only: all workflow semantics remain
+owned by the route documents above. If any documented command's executable
+cannot be resolved, state the missing prerequisite and stop that route
+instead of substituting a different tool.


### PR DESCRIPTION
## 改动内容

对 `skills/ppt-master/SKILL.md` 做两处改进（纯增量，不动任何工作流/门禁语义）：

### 1. description 增加中文触发意图

DeepSeek Harness 等 agent 平台按 description 匹配用户请求。原描述只有英文，中文用户说"帮我做个 PPT / 美化这份演示文稿"时触发不稳定。新增中文触发词：

- 制作/生成/美化 PPT、做幻灯片/演示文稿/课件
- PPT 模板填充、PPTX 转图重绘、给 PPT 加配音/动画

### 2. 新增 "Runtime Environment Discovery" 段

skill 被 agent 加载时，模型拿到的是 SKILL.md 文本，不一定知道磁盘路径；而工作流要求"从 skill 目录运行脚本"。新段给出：

- 用文件搜索定位 `attribution_guard.py` 推导 skill 根目录（例举 `~/.dsh/skills/ppt-master`、`~/.claude/skills/ppt-master`、`~/.agents/skills/ppt-master`）
- 一律用绝对路径/显式 cd 运行命令，禁止 CWD 猜测
- Windows 上 Python 解析顺序：`python` → `py -3`，并用 `python -c "import pptx"` 探测依赖齐备的解释器
- 定位/启动器只是 shim，不改变任何路由语义；找不到可执行文件时按路由规则停机，不擅自替换工具

## 兼容性验证

- `attribution_guard.py` 门禁通过（exit 0）：三个精确元数据字段未动、gate marker 字符串仍恰好出现 1 次、LICENSE 摘要未动、13 个 gate 脚本未碰
- 在 DeepSeek Harness 0.1.0-rc.5 上实测：中文触发词生效，路径发现流程可执行

---
*PR 由 AI 协助撰写。*