### PR TITLE
skill: 扩 description 意图词并补 Skill 根目录来源说明（#266 修订）

### DIFF
--- a/skills/ppt-master/SKILL.md
+++ b/skills/ppt-master/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: ppt-master
 description: >
-  AI-driven presentation workflow for generating editable PPTX decks,
+  AI-driven presentation workflow for generating editable PPTX decks and slides,
   reconstructing page visuals, creating reusable Brand/Style/Layout/Deck
   workspaces, filling native PPTX templates, and enhancing finished PPTX files.
-  Use when the user asks to create, reconstruct, regenerate, template, fill, or
-  enhance a presentation, requests a presentation-authored narrated/self-running
-  video, or mentions ppt-master.
+  Use when the user asks to create, generate, reconstruct, regenerate, beautify,
+  redesign, template, fill, or enhance a presentation, PPT, PPTX, slide deck, or
+  courseware — including adding narration or animation to one — requests a
+  presentation-authored narrated/self-running video, or mentions ppt-master.
 metadata:
   version: "4.7.0"
   copyright: "Copyright (c) 2025-2026 Hugo He"
@@ -60,7 +61,7 @@ never compete with it.
 5. **No speculative execution** — Do not prepare later-phase artifacts before their owning step.
 6. **Deterministic routing** — Do not add a route-choice question when [`routing.md`](workflows/routing.md) resolves the request. If a route prerequisite is missing, state it and stop that route.
 7. **Owning-source recovery** — On failure, repair or regenerate the owning source artifact and resume from the route's declared pointer. Do not silently downgrade a required artifact.
-8. **Stable paths** — Use absolute skill/project paths; never derive them from CWD.
+8. **Stable paths** — Use absolute skill/project paths; never derive them from CWD. The Skill root is the directory that contains `SKILL.md`, and the host provides its path when loading the Skill; if that path cannot be determined, ask the user — never guess it via file search.
 
 ## Global Communication Rules
 


### PR DESCRIPTION
## What & why

本 PR 是 #266 的修订版，按维护者在 [#266 评论 5299983639](https://github.com/hugohe3/ppt-master/pull/266#issuecomment-5299983639) 中确认的方向重做，只改 `skills/ppt-master/SKILL.md`（纯增量，2 处 hunk）：

1. **扩 `description` 英文意图词**：补充 `generate` / `beautify` / `redesign`、`PPT` / `slide deck` / `courseware`、`narration` / `animation` 等意图词，覆盖制作、美化、课件、模板填充、转图重绘、配音/动画六类；不加任何语言关键词表，description 保持语言中立英文散文（符合 [`docs/rules/language.md`](docs/rules/language.md) §4）。
2. **补一句消掉路径真空**（Global Execution Discipline #8）：Skill 根目录就是包含 `SKILL.md` 的目录，宿主加载时提供其路径；无法确定时向用户询问，不用文件搜索猜测。一句话，不引入机制。

明确不含：#266 讨论中的排除项——具体 harness 名/私有路径、搜 `attribution_guard.py` 反推根目录、`python`/`py -3` 解释器口径。

## Verification

- `python scripts/attribution_guard.py`（skill 目录内运行）→ exit 0：三个精确元数据字段未动、gate marker 仍恰好 1 次、LICENSE 摘要与 13 个 gate 脚本未碰。
- diff（base = upstream main `090a1330`）仅 2 处 hunk（+6/−5），无其他文件变动。
- 推送内容与本地校验文件字节一致。

## Confirmations

**All three of the following must be checked. If any one is left unchecked, the PR is closed without review.**

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I personally reviewed the full diff and verified every claim in this description against this repository's actual code — including that the problem is real here and the capability isn't already provided by an existing path or already fixed on `main` (purely AI-generated PRs without human review are closed unmerged)
- [x] This PR is code-only, **or** it touches prompt/instruction text (`SKILL.md`, `references/*.md`, `workflows/*.md`, …) and was discussed and agreed in an issue first — link it here: #266（维护者在 #266 评论 5299983639 明确豁免前置 issue："这次不再要求你补 issue……直接提新 PR 即可"）
