### PR TITLE
fix(image-gen): handle documented image_urls response shape in MiniMax backend

### DIFF
--- a/skills/ppt-master/scripts/image_backends/backend_minimax.py
+++ b/skills/ppt-master/scripts/image_backends/backend_minimax.py
@@ -33,6 +33,7 @@ import requests
 from image_backends.backend_common import (
     MAX_RETRIES,
     detect_image_extension,
+    download_image,
     http_error,
     is_rate_limit_error,
     normalize_image_size,
@@ -46,6 +47,11 @@ from image_backends.backend_common import (
 DEFAULT_ENDPOINT = "https://api.minimaxi.com/v1/image_generation"
 DEFAULT_MODEL = "image-01"
 SUPPORTED_MODELS = {DEFAULT_MODEL}
+
+# Request the documented default response format. The API returns hosted links
+# in `data.image_urls` for "url" and inline strings in `data.image_base64` for
+# "base64"; both shapes are handled when the response is parsed.
+DEFAULT_RESPONSE_FORMAT = "url"
 
 # International fallback: set MINIMAX_BASE_URL=https://api.minimax.io if needed
 
@@ -130,11 +136,20 @@ def _resolve_dimensions(aspect_ratio: str, image_size: str) -> tuple[int, int]:
 
 
 def _extract_image_bytes(payload: dict) -> bytes | None:
-    """Extract image bytes from a MiniMax response payload."""
+    """Extract inline base64 image bytes from a MiniMax response payload."""
     data = payload.get("data") or {}
     image_base64 = data.get("image_base64") or []
     if image_base64:
         return base64.b64decode(image_base64[0])
+    return None
+
+
+def _extract_image_url(payload: dict) -> str | None:
+    """Extract the first hosted image URL from a MiniMax response payload."""
+    data = payload.get("data") or {}
+    image_urls = data.get("image_urls") or []
+    if image_urls:
+        return image_urls[0]
     return None
 
 
@@ -156,7 +171,7 @@ def _generate_image(api_key: str, prompt: str,
         "prompt": prompt,
         "width": width,
         "height": height,
-        "response_format": "base64",
+        "response_format": DEFAULT_RESPONSE_FORMAT,
         "n": 1,
     }
 
@@ -181,12 +196,19 @@ def _generate_image(api_key: str, prompt: str,
         raise RuntimeError(f"MiniMax image generation failed: {data}")
 
     image_bytes = _extract_image_bytes(data)
-    if not image_bytes:
-        raise RuntimeError(f"MiniMax response missing image data: {data}")
+    if image_bytes:
+        ext = detect_image_extension(image_bytes) or ".jpeg"
+        path = resolve_output_path(prompt, output_dir, filename, ext)
+        return save_image_bytes(image_bytes, path)
 
-    ext = detect_image_extension(image_bytes) or ".jpeg"
-    path = resolve_output_path(prompt, output_dir, filename, ext)
-    return save_image_bytes(image_bytes, path)
+    image_url = _extract_image_url(data)
+    if image_url:
+        # image-01 serves JPEG; save_image_bytes realigns the extension when the
+        # downloaded bytes are a different format.
+        path = resolve_output_path(prompt, output_dir, filename, ".jpeg")
+        return download_image(image_url, path)
+
+    raise RuntimeError(f"MiniMax response missing image data: {data}")
 
 
 def generate(prompt: str,


### PR DESCRIPTION
Reason: The MiniMax image backend requested base64 and parsed only `data.image_base64`, so the documented default response shape `data.image_urls` was never handled.

## Background

The image generation endpoint documents `response_format` with two allowed values, `url` (the default) and `base64`. The response carries `data.image_urls` in `url` mode and `data.image_base64` in `base64` mode.

`backend_minimax.py` hard-coded `"response_format": "base64"`, and `_extract_image_bytes()` read only `data.image_base64`. A response that came back in the documented default shape therefore fell through to `RuntimeError: MiniMax response missing image data` even though the payload carried a usable image link.

## Changes

All in `skills/ppt-master/scripts/image_backends/backend_minimax.py`:

- Request the documented default format through a new `DEFAULT_RESPONSE_FORMAT = "url"` constant instead of the hard-coded `"base64"`.
- Add `_extract_image_url()`, which returns the first entry of `data.image_urls`.
- When the response carries a hosted link, save it through the shared `download_image()` helper from `backend_common`. The inline `data.image_base64` branch is unchanged, so both documented response shapes now work.
- The missing-image `RuntimeError` now fires only when neither field is present.

No new configuration keys and no dependency changes: `download_image()` and `save_image_bytes()` already lived in `backend_common`.

## Checks

Per `docs/rules/code-style.md` §11 this repository ships no automated tests, so the parsing paths were exercised with an inline smoke run against stubbed HTTP responses. Nothing was added to the repository for it.

- `python3 -m py_compile skills/ppt-master/scripts/image_backends/backend_minimax.py` — clean.
- `ruff check skills/ppt-master/scripts/image_backends/backend_minimax.py` — 5 pre-existing `E402` findings, the same count before and after this change (the deliberate post-injection import pattern documented in the code-style rules).
- Smoke run observations:
  - `url` mode: the request sends `response_format="url"`, and the link from `data.image_urls` is downloaded and saved as `smoke.jpeg` (verified JPEG, 16x9). On `main` this same payload raises `MiniMax response missing image data`.
  - `url` mode where the hosted bytes are PNG: `save_image_bytes()` realigns the extension instead of writing a mislabeled file.
  - `base64` mode: `data.image_base64` still decodes and saves (`smoke.jpg`, verified JPEG, 16x9).
  - empty `data`: raises `RuntimeError` reporting the missing image data.
  - non-zero `base_resp.status_code`: still raises before any image parsing.
