### PR TITLE
fix: verify wrapped Python daemon processes

### DIFF
--- a/skills/ppt-master/scripts/confirm_ui/server.py
+++ b/skills/ppt-master/scripts/confirm_ui/server.py
@@ -1062,12 +1062,17 @@ def _wait_for_server_ready(
         try:
             with urllib.request.urlopen(health_url, timeout=1) as resp:
                 data = json.load(resp)
+                lock = _read_lock(project_path / LOCK_FILE_NAME)
+                server_pid = _lock_pid(lock)
                 if (
                     resp.status == 200
                     and isinstance(data, dict)
                     and data.get('service') == 'confirm_ui'
                     and data.get('project') == str(project_path)
-                    and data.get('pid') == proc.pid
+                    and lock is not None
+                    and lock.get('port') == port
+                    and data.get('pid') == server_pid
+                    and _process_alive(server_pid)
                 ):
                     return True
                 last_error = 'health response belongs to another service or project'

--- a/skills/ppt-master/scripts/svg_editor/server.py
+++ b/skills/ppt-master/scripts/svg_editor/server.py
@@ -1077,12 +1077,17 @@ def _wait_for_ready(
         try:
             with urllib.request.urlopen(health_url, timeout=1) as response:
                 data = json.load(response)
+                lock = _read_lock(_lock_file(project_path))
+                server_pid = _lock_pid(lock)
                 if (
                     response.status == 200
                     and isinstance(data, dict)
                     and data.get('service') == 'live_preview'
                     and data.get('project') == str(project_path)
-                    and data.get('pid') == proc.pid
+                    and lock is not None
+                    and lock.get('port') == port
+                    and data.get('pid') == server_pid
+                    and _process_alive(server_pid)
                 ):
                     return True
                 last_error = 'health response belongs to another service or project'


### PR DESCRIPTION
## What & why

On Windows, a Python executable may be a launcher or wrapper rather than the process that ultimately runs the Flask server. A uv-created virtual environment provides a deterministic reproduction: its `Scripts\python.exe` trampoline starts the real interpreter as a child process.

Both daemon readiness checks assumed that the launcher PID returned by `subprocess.Popen` must equal the PID reported by the Flask process:

```text
launcher Popen.pid == health os.getpid()
```

That assumption fails for wrapped Python executables. The server starts normally, returns HTTP 200 with the correct service and project, and writes its real PID and port to the existing project lock, but the launcher rejects it after the startup timeout because the two PIDs differ.

The affected paths were:

- `confirm_ui/server.py::_wait_for_server_ready`
- `svg_editor/server.py::_wait_for_ready`

This change binds readiness to the existing daemon identity protocol instead. Each launcher now requires:

- an HTTP 200 health response;
- the expected service and absolute project path;
- a health PID matching the PID in the project lock;
- a lock port matching the requested port; and
- a live server PID.

The existing `proc.poll()` check remains in place so a launcher that exits abnormally before readiness is still detected.

This is a focused daemon bug fix, not an adoption of uv. It adds no dependency, lockfile, installer change, README recommendation, or uv-specific runtime branch. The official `pip install -r requirements.txt` path is unchanged; uv is only the reproduction environment for a generic wrapped-executable PID assumption.

Closes #277

## Verification

Environment:

```text
Windows 11 build 22631.4317
uv 0.12.5
CPython 3.13.13
```

Before the change, both real daemon commands reproduced the failure:

- Confirm UI exited non-zero after 10 seconds with `health response belongs to another service or project`.
- SVG live preview exited non-zero after 15 seconds with the same error.

After the change:

- Confirm UI started successfully under the uv virtual environment, returned matching health/lock identity, and `--shutdown` stopped the real server process. The observed launcher PID was `49800`; the health/lock server PID was `63548`.
- SVG live preview started successfully with `--live --daemon`, returned matching health/lock identity, and `--shutdown` stopped the real server process. The observed launcher PID was `11216`; the health/lock server PID was `61584`.
- Both daemons also started and shut down successfully with the non-trampoline base Python interpreter.
- A temporary protocol smoke harness confirmed that both readiness checks still reject a wrong service, wrong project, mismatched lock port, and stale lock PID. The harness was deleted after the run; no test files or test framework were added.

Commands/checks completed:

```text
python -m py_compile skills/ppt-master/scripts/confirm_ui/server.py skills/ppt-master/scripts/svg_editor/server.py
python -m compileall -q skills/ppt-master/scripts
python skills/ppt-master/scripts/attribution_guard.py
PYTHONUTF8=1 python -m unittest discover -s skills/ppt-master/scripts/tests -p "test_*.py"
```

Result: the existing test suite passed, 40/40.

## Confirmations

**All three of the following must be checked. If any one is left unchecked, the PR is closed without review.**

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I personally reviewed the full diff and verified every claim in this description against this repository's actual code — including that the problem is real here and the capability isn't already provided by an existing path or already fixed on `main` (purely AI-generated PRs without human review are closed unmerged)
- [x] This PR is code-only, **or** it touches prompt/instruction text (`SKILL.md`, `references/*.md`, `workflows/*.md`, …) and was discussed and agreed in an issue first — link it here: #277
