### PR TITLE
fix: open preview URLs in Windows browser under WSL

### DIFF
--- a/skills/ppt-master/scripts/confirm_ui/server.py
+++ b/skills/ppt-master/scripts/confirm_ui/server.py
@@ -46,7 +46,6 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-import webbrowser
 from pathlib import Path
 from typing import Optional
 
@@ -68,6 +67,7 @@ from server_common import (  # noqa: E402
     clear_lock as _clear_lock,
     find_free_port as _find_free_port,
     lock_pid as _lock_pid,
+    open_preview_browser,
     popen_detached as _popen_detached,
     process_alive as _process_alive,
     read_lock as _read_lock,
@@ -1134,7 +1134,7 @@ def _launch_background_server(
     url = _server_url(port)
     logger.info('started confirm UI in background: %s (pid=%s)', url, server_pid)
     if open_browser:
-        webbrowser.open(url)
+        open_preview_browser(url, logger=logger)
     return proc, port, log_path
 
 
@@ -1162,7 +1162,7 @@ def _open_browser_async(url: str, delay: float = 0.4) -> None:
     """Open the browser after Flask has had a moment to bind its socket."""
     def _open() -> None:
         time.sleep(delay)
-        webbrowser.open(url)
+        open_preview_browser(url, logger=logger)
 
     threading.Thread(target=_open, daemon=True).start()
 
@@ -3122,7 +3122,7 @@ def main(argv: Optional[list[str]] = None) -> int:
                 logger.error('%s', exc)
                 return 1
             if actual_port != recovery_port and not args.no_browser:
-                webbrowser.open(_server_url(actual_port))
+                open_preview_browser(_server_url(actual_port), logger=logger)
             logger.info(
                 'recovered confirm UI for wait-only at %s; the browser polling should resume',
                 _server_url(actual_port),

--- a/skills/ppt-master/scripts/server_common.py
+++ b/skills/ppt-master/scripts/server_common.py
@@ -4,7 +4,7 @@ PPT Master - Local Preview Server Helpers
 
 Shared per-project mutual-exclusion (lock) and liveness helpers for the local
 Flask preview servers (`svg_editor/server.py`, `confirm_ui/server.py`). Each
-server keeps its own lock filename and Flask app; this module owns only the
+server keeps its own lock filename and Flask app; this module owns browser dispatch, the
 cross-platform process-liveness check and the claim/read/release lock logic so
 the two servers cannot drift apart.
 
@@ -15,11 +15,15 @@ Dependencies:
     None (only uses standard library)
 """
 
+import base64
 import json
 import logging
 import os
+import platform
+import shutil
 import socket
 import subprocess
+import webbrowser
 from pathlib import Path
 from typing import Optional
 
@@ -28,6 +32,57 @@ from workflow_transcript import DISABLE_TRANSCRIPT_ENV
 
 MIN_PORT = 1
 MAX_PORT = 65535
+
+
+# Windows PowerShell as mounted inside WSL; probed when ``[interop]
+# appendWindowsPath=false`` keeps interop but drops Windows dirs from PATH.
+WSL_POWERSHELL = '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe'
+
+
+def _wsl_powershell() -> Optional[str]:
+    """Return the Windows PowerShell path when running under WSL, else ``None``."""
+    if 'microsoft' not in platform.release().lower():
+        return None
+    found = shutil.which('powershell.exe')
+    if found:
+        return found
+    return WSL_POWERSHELL if os.access(WSL_POWERSHELL, os.X_OK) else None
+
+
+def open_preview_browser(url: str, logger: Optional[logging.Logger] = None) -> bool:
+    """Ask the host OS to open a preview URL; this does not verify window visibility.
+
+    ``BROWSER`` keeps its usual ``webbrowser`` meaning everywhere. Without it,
+    WSL asks Windows PowerShell for the Windows default browser: WSL's ``gio``
+    may exist without an HTTP handler, and ``webbrowser`` reports success as
+    soon as that child spawns. Every other host uses ``webbrowser`` unchanged.
+    """
+    log = logger or logging.getLogger(__name__)
+    try:
+        powershell = None if os.environ.get('BROWSER') else _wsl_powershell()
+        if powershell:
+            # Keep the URL as data, including quotes, ampersands and non-ASCII text.
+            encoded_url = base64.b64encode(url.encode('utf-8')).decode('ascii')
+            script = (
+                "$ErrorActionPreference = 'Stop'; "
+                "$u = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('"
+                + encoded_url + "')); Start-Process -FilePath $u"
+            )
+            command = base64.b64encode(script.encode('utf-16le')).decode('ascii')
+            result = subprocess.run(
+                [powershell, '-NoProfile', '-NonInteractive', '-EncodedCommand', command],
+                capture_output=True, timeout=15, check=False,
+            )
+            if result.returncode:
+                detail = result.stderr.decode('utf-8', errors='replace').strip()
+                raise OSError(f'PowerShell exited {result.returncode}: {detail}')
+        elif not webbrowser.open(url):
+            raise OSError('no browser accepted the URL')
+        log.info('browser launch request accepted by OS: %s', url)
+        return True
+    except (OSError, subprocess.TimeoutExpired, webbrowser.Error) as exc:
+        log.warning('browser launch failed: %s; open %s manually', exc, url)
+        return False
 
 
 def validate_port(port: int) -> int:

--- a/skills/ppt-master/scripts/svg_editor/server.py
+++ b/skills/ppt-master/scripts/svg_editor/server.py
@@ -32,7 +32,6 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-import webbrowser
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Iterable, Optional
@@ -68,6 +67,7 @@ from server_common import (  # noqa: E402
     clear_lock as _clear_lock,
     find_free_port as _find_free_port,
     lock_pid as _lock_pid,
+    open_preview_browser,
     popen_detached as _popen_detached,
     process_alive as _process_alive,
     read_lock as _read_lock,
@@ -1125,17 +1125,7 @@ def _wait_for_ready(
 
 
 def _open_browser(url: str) -> bool:
-    """Best-effort browser launch after the local server is reachable."""
-    try:
-        if os.name == 'nt':
-            os.startfile(url)  # type: ignore[attr-defined]
-            return True
-        return bool(webbrowser.open(url))
-    except OSError as exc:
-        logger.warning('browser auto-open failed: %s', exc)
-    except webbrowser.Error as exc:
-        logger.warning('browser auto-open failed: %s', exc)
-    return False
+    return open_preview_browser(url, logger=logger)
 
 
 def _reuse_running_server(

--- a/skills/ppt-master/scripts/tests/test_preview_browser.py
+++ b/skills/ppt-master/scripts/tests/test_preview_browser.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Regression tests for local preview browser dispatch across Windows and WSL."""
+
+import base64
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import server_common as common  # noqa: E402
+from svg_editor import server as editor  # noqa: E402
+
+URL = 'http://127.0.0.1:6060'
+
+
+class PreviewBrowserTests(unittest.TestCase):
+    """Default fixture: WSL2 with powershell.exe on PATH and no BROWSER override."""
+
+    def setUp(self) -> None:
+        env = patch.dict(os.environ)
+        env.start()
+        self.addCleanup(env.stop)
+        os.environ.pop('BROWSER', None)
+        for target, value in (
+            ('server_common.platform.release', '6.18-microsoft-standard-WSL2'),
+            ('server_common.shutil.which', '/windows/powershell.exe'),
+        ):
+            mock = patch(target, return_value=value)
+            mock.start()
+            self.addCleanup(mock.stop)
+
+    def test_wsl_uses_windows_browser_and_encodes_url_as_data(self) -> None:
+        url = "http://127.0.0.1:6060/?q=';&name=演示"
+        ok = subprocess.CompletedProcess([], 0)
+        with patch.object(common.subprocess, 'run', return_value=ok) as run:
+            with patch.object(common.webbrowser, 'open') as browser:
+                self.assertTrue(editor._open_browser(url))
+        browser.assert_not_called()
+        args = run.call_args.args[0]
+        self.assertEqual(
+            args[:4], ['/windows/powershell.exe', '-NoProfile', '-NonInteractive', '-EncodedCommand'],
+        )
+        script = base64.b64decode(args[4]).decode('utf-16le')
+        self.assertIn(base64.b64encode(url.encode()).decode(), script)
+        self.assertNotIn(url, script)
+        self.assertIn('Start-Process -FilePath $u', script)
+        self.assertEqual(run.call_args.kwargs['timeout'], 15)
+
+    def test_wsl_probes_mounted_powershell_when_path_lacks_windows_dirs(self) -> None:
+        ok = subprocess.CompletedProcess([], 0)
+        with patch.object(common.shutil, 'which', return_value=None):
+            with patch.object(common.os, 'access', return_value=True):
+                with patch.object(common.subprocess, 'run', return_value=ok) as run:
+                    with patch.object(common.webbrowser, 'open') as browser:
+                        self.assertTrue(common.open_preview_browser(URL))
+        browser.assert_not_called()
+        self.assertEqual(run.call_args.args[0][0], common.WSL_POWERSHELL)
+
+    def test_browser_env_keeps_webbrowser_dispatch_on_wsl(self) -> None:
+        os.environ['BROWSER'] = 'wslview'
+        with patch.object(common.subprocess, 'run') as run:
+            with patch.object(common.webbrowser, 'open', return_value=True) as browser:
+                self.assertTrue(common.open_preview_browser(URL))
+        run.assert_not_called()
+        browser.assert_called_once_with(URL)
+
+    def test_windows_keeps_webbrowser_dispatch(self) -> None:
+        with patch.object(common.platform, 'release', return_value='10'):
+            with patch.object(common.subprocess, 'run') as run:
+                with patch.object(common.webbrowser, 'open', return_value=True) as browser:
+                    self.assertTrue(common.open_preview_browser(URL))
+        run.assert_not_called()
+        browser.assert_called_once_with(URL)
+
+    def test_linux_keeps_webbrowser_dispatch(self) -> None:
+        with patch.object(common.platform, 'release', return_value='6.8-linux'):
+            with patch.object(common.webbrowser, 'open', return_value=True) as browser:
+                self.assertTrue(common.open_preview_browser(URL))
+                browser.assert_called_once()
+
+    def test_wsl_without_powershell_keeps_webbrowser_fallback(self) -> None:
+        with patch.object(common.shutil, 'which', return_value=None):
+            with patch.object(common.os, 'access', return_value=False):
+                with patch.object(common.webbrowser, 'open', return_value=True) as browser:
+                    self.assertTrue(common.open_preview_browser(URL))
+        browser.assert_called_once_with(URL)
+
+    def test_powershell_failures_preserve_manual_url(self) -> None:
+        failures = [
+            OSError('interop unavailable'),
+            subprocess.TimeoutExpired('powershell.exe', 15),
+        ]
+        for error in failures:
+            run = patch.object(common.subprocess, 'run', side_effect=error)
+            with self.subTest(error=error), run:
+                with self.assertLogs('server_common', level='WARNING') as logs:
+                    self.assertFalse(common.open_preview_browser(URL))
+                self.assertIn(f'open {URL} manually', logs.output[0])
+
+    def test_nonzero_powershell_exit_is_failure(self) -> None:
+        result = subprocess.CompletedProcess([], 1, b'', b'no application')
+        with patch.object(common.subprocess, 'run', return_value=result):
+            with self.assertLogs('server_common', level='WARNING'):
+                self.assertFalse(common.open_preview_browser(URL))
+
+    def test_webbrowser_false_is_failure(self) -> None:
+        with patch.object(common.platform, 'release', return_value='6.8-linux'):
+            with patch.object(common.webbrowser, 'open', return_value=False):
+                with self.assertLogs('server_common', level='WARNING'):
+                    self.assertFalse(common.open_preview_browser(URL))
+


### PR DESCRIPTION
## What & why

On WSL2 with `gio` on PATH but no default HTTP handler, both preview entry points use Python's Linux `webbrowser` dispatch, so they can serve a page without opening the Windows browser. The SVG editor's native Windows branch does not apply to WSL (`os.name == "posix"`).

Use a shared browser helper for Confirm UI and the SVG editor. On WSL with PowerShell available, request the Windows default browser with `Start-Process`. Encode the URL as data, bound the subprocess wait, and report launch failures with the manual URL. Keep native Windows dispatch and the generic webbrowser path for other hosts or WSL without PowerShell.

Reproduction: on WSL with PowerShell on PATH, `webbrowser.get().name` returns `gio` and `gio mime x-scheme-handler/http` reports no default application. Start either configured preview entry point with `--daemon` and observe that the service can be ready while automatic browser opening fails. Local-network sandbox permissions must already allow the preview service; this patch does not change those permissions.

## Verification

- Rebased on upstream main `f76d1ecb4185a61e107702d6244b41f487834cc4`; all 15 regression tests rerun successfully. Generic smoke tests were completed before the rebase; intervening upstream changes do not touch either preview entry point or their shared helper.
- Python 3.13, Ubuntu on WSL2: 7 browser-dispatch regression tests, 2 existing SVG editor tests, and 6 existing local-server security tests passed (standard-library unittest).
- Ran patched SVG editor with a synthetic SVG containing only generic browser-test text: health, homepage and slide-list endpoints returned HTTP 200. Windows accepted the browser launch request.
- Ran patched Confirm UI with independently generated generic template options and recommendations: health and homepage returned HTTP 200; Windows accepted the browser launch request.
- Both smoke-test services were shut down after verification. The reported smoke tests use synthetic fixtures only.
- Windows and non-WSL Linux dispatch paths were mocked in regression tests; no native Windows/Linux runtime verification is claimed. OS acceptance does not prove window visibility.
- `git diff --cached --check` passed.

## Confirmations

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I personally reviewed the full diff and verified every claim in this description against this repository's actual code — including that the problem is real here and the capability isn't already provided by an existing path or already fixed on `main` (purely AI-generated PRs without human review are closed unmerged)
- [x] This PR is code-only; it does not modify prompt/instruction text.
